### PR TITLE
Bug 1165259 - Correct the RDS SSL instructions

### DIFF
--- a/treeherder/README
+++ b/treeherder/README
@@ -4,19 +4,27 @@
 After creating the RDS instance, configure the master account to require SSL, per
 http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport
 
-$ wget http://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
-$ mysql -h host -u username -p
+Download the RDS CA bundle:
+$ wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
+
+Connect securely to the RDS instance:
+* mysql client <5.6.30 or 5.7.0-5.7.10
+  Don't use, vulnerable to MITM! (CVE-2015-3152)
+* mysql client 5.6.30+
+  $ mysql -h host -u username -p --ssl-mode=REQUIRED --ssl-verify-server-cert --ssl_ca=rds-combined-ca-bundle.pem
+* mysql client 5.7.11+
+  $ mysql -h host -u username -p --ssl-mode=VERIFY_IDENTITY --ssl_ca=rds-combined-ca-bundle.pem
+
+Once connected, configure future connections to only be accepted over SSL:
 mysql> GRANT USAGE ON *.* TO 'username'@'%' REQUIRE SSL;
 
-Thereafter, connect to mysql with SSL:
-
-$ mysql -h host --ssl_ca=rds-combined-ca-bundle.pem --ssl-verify-server-cert -u username -p
-
+Thereafter, always connect to mysql using SSL, using the same commands as above.
+NB: Even with `REQUIRE SSL` set, client connections are still vulnerable to leaking
+credentials via MITM, unless the appropriate `--ssl-mode` option is used.
 
 # Param groups
+
 Some parameters may be modified dynamically, while others are static and thus require a reboot to apply. Static params must have 'apply_method' set to 'pending-reboot', rather than the default of 'immediate'.
 
 A quick and dirty query to list all static params:
 aws rds describe-db-parameters --db-parameter-group-name default.mysql5.6 | jq -r '.Parameters | map([.ParameterName, .ApplyType] | join(", "))' | grep static
-
-


### PR DESCRIPTION
- Use HTTPS not HTTP to download the CA bundle.
- Get the user to connect over SSL when setting REQUIRE SSL.
- Set `--ssl-mode` to prevent connections being MITMed.
