### PR TITLE
Bug 1308970 - Treeherder RDS: Switch log_output from TABLE to FILE

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -194,6 +194,10 @@ resource "aws_db_parameter_group" "treeherder-pg" {
         value = "utf8_bin"
     }
     parameter {
+        name = "log_output"
+        value = "FILE"
+    }
+    parameter {
         name = "long_query_time"
         value = "2"
     }


### PR DESCRIPTION
To reduce DB writes and make use of improved automation rotation, which will reduce any performance impact if a large number of slow queries are logged.

http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.MySQL.html
http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_log_output
