### PR TITLE
Bug 1306976 - Treeherder RDS: Enable STRICT_ALL_TABLES sql_mode

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -201,6 +201,10 @@ resource "aws_db_parameter_group" "treeherder-pg" {
         name = "slow_query_log"
         value = "1"
     }
+    parameter {
+        name = "sql_mode"
+        value = "NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
+    }
 }
 
 resource "aws_db_instance" "treeherder-heroku" {


### PR DESCRIPTION
For consistency with the Vagrant/Travis config:
https://github.com/mozilla/treeherder/blob/c88a9fb3fa5fd4d60dc6d3438fee5c65c9e91dae/puppet/files/mysql/my.cnf#L8-L12

Also sets `NO_ENGINE_SUBSTITUTION`, since that's already set by default for MySQL 5.6.6+ (the Vagrant/Travis config will be updated to match):
http://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_sql-mode
http://dev.mysql.com/doc/refman/5.6/en/sql-mode.html#sql-mode-strict
