### PR TITLE
Environment for GitHub Web Hooks processing

### DIFF
--- a/githubwebhooks/README.rst
+++ b/githubwebhooks/README.rst
@@ -1,0 +1,27 @@
+GitHub Web Hooks Processing
+===========================
+
+This directory contains a Terraform environment defining the GitHub
+web hooks ingestion and processing mechanism.
+
+From a high-level:
+
+* An API Gateway processes HTTP requests from GitHub and hands them
+  off to a Lambda function to process them.
+* The Lambda function writes events to a Kinesis Firehose and SNS
+  topics. One topic contains all events. Another contains only the
+  *public* events.
+* The Kinesis Firehose writes events to S3, where they are retained
+  forever so we have historical data.
+* A Lambda function listens for events on the *public* topic and
+  republishes them to Pulse, Mozilla's AMQP exchange.
+
+Supporting all of this are:
+
+* CloudWatch log groups so everything can log activity.
+* IAM roles and policies to allow everything to talk to each other.
+
+The Lambda functions are defined in the version-control-tools
+repository. That repository has its own code for uploading a new
+version of the execution environment and triggering a refresh of the
+Lambda environment.

--- a/githubwebhooks/apigateway.tf
+++ b/githubwebhooks/apigateway.tf
@@ -1,0 +1,109 @@
+resource "aws_api_gateway_account" "account" {
+}
+
+resource "aws_api_gateway_rest_api" "webhooks" {
+    name = "GitHub-WebHook"
+    description = "Receives GitHub web hook notifications"
+}
+
+resource "aws_api_gateway_resource" "webhook" {
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    parent_id = "${aws_api_gateway_rest_api.webhooks.root_resource_id}"
+    path_part = "webhook"
+}
+
+resource "aws_api_gateway_method" "webhook_post" {
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    resource_id = "${aws_api_gateway_resource.webhook.id}"
+    http_method = "POST"
+    authorization = "NONE"
+    request_parameters = {
+        "method.request.header.X-GitHub-Delivery" = true
+        "method.request.header.X-GitHub-Event" = true
+    }
+}
+
+resource "aws_api_gateway_integration" "webhook_post_lambda" {
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    resource_id = "${aws_api_gateway_resource.webhook.id}"
+    http_method = "${aws_api_gateway_method.webhook_post.http_method}"
+    type = "AWS"
+    uri = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.lambda_receive.arn}/invocations"
+    integration_http_method = "POST"
+    passthrough_behavior = "WHEN_NO_TEMPLATES"
+    request_templates = {
+        "application/json" = <<EOF
+##  See http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+##  This template will pass through all parameters including path, querystring, header, stage variables, and context through to the integration endpoint via the body/payload
+#set($allParams = $input.params())
+{
+"body-json" : $input.json('$'),
+"params" : {
+#foreach($type in $allParams.keySet())
+    #set($params = $allParams.get($type))
+"$type" : {
+    #foreach($paramName in $params.keySet())
+    "$paramName" : "$util.escapeJavaScript($params.get($paramName))"
+        #if($foreach.hasNext),#end
+    #end
+}
+    #if($foreach.hasNext),#end
+#end
+},
+"stage-variables" : {
+#foreach($key in $stageVariables.keySet())
+"$key" : "$util.escapeJavaScript($stageVariables.get($key))"
+    #if($foreach.hasNext),#end
+#end
+},
+"context" : {
+    "account-id" : "$context.identity.accountId",
+    "api-id" : "$context.apiId",
+    "api-key" : "$context.identity.apiKey",
+    "authorizer-principal-id" : "$context.authorizer.principalId",
+    "caller" : "$context.identity.caller",
+    "cognito-authentication-provider" : "$context.identity.cognitoAuthenticationProvider",
+    "cognito-authentication-type" : "$context.identity.cognitoAuthenticationType",
+    "cognito-identity-id" : "$context.identity.cognitoIdentityId",
+    "cognito-identity-pool-id" : "$context.identity.cognitoIdentityPoolId",
+    "http-method" : "$context.httpMethod",
+    "stage" : "$context.stage",
+    "source-ip" : "$context.identity.sourceIp",
+    "user" : "$context.identity.user",
+    "user-agent" : "$context.identity.userAgent",
+    "user-arn" : "$context.identity.userArn",
+    "request-id" : "$context.requestId",
+    "resource-id" : "$context.resourceId",
+    "resource-path" : "$context.resourcePath"
+    }
+}
+EOF
+    }
+}
+
+resource "aws_api_gateway_method_response" "200" {
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    resource_id = "${aws_api_gateway_resource.webhook.id}"
+    http_method = "${aws_api_gateway_method.webhook_post.http_method}"
+    status_code = "200"
+    response_models {
+        "application/json" = "Empty"
+    }
+}
+
+resource "aws_api_gateway_integration_response" "response" {
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    resource_id = "${aws_api_gateway_resource.webhook.id}"
+    http_method = "${aws_api_gateway_method.webhook_post.http_method}"
+    status_code = "${aws_api_gateway_method_response.200.status_code}"
+}
+
+resource "aws_api_gateway_deployment" "webhook_prod_deployment" {
+    depends_on = [
+        "aws_api_gateway_method.webhook_post"
+    ]
+
+    rest_api_id = "${aws_api_gateway_rest_api.webhooks.id}"
+    stage_name = "prod"
+    description = "Production instance of GitHub web hooks ingestion"
+}

--- a/githubwebhooks/cloudwatch.tf
+++ b/githubwebhooks/cloudwatch.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_log_group" "lambda_receive" {
+    name = "/aws/lambda/github-webhooks-receive"
+    retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "lambda_pulse" {
+    name = "/aws/lambda/github-webhooks-pulse"
+    retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "kinesisfirehose_github_webhooks" {
+    name = "/aws/kinesisfirehose/github-webhooks"
+    retention_in_days = 30
+}

--- a/githubwebhooks/iam-roles.tf
+++ b/githubwebhooks/iam-roles.tf
@@ -1,0 +1,168 @@
+# The lambda receive role + policy allows:
+# * Writing to CloudWatch
+# * Writing to the firehose
+# * Writing to SNS
+resource "aws_iam_role" "lambda_github_webhooks_receive" {
+    name = "lambda-github-webhooks-receive"
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "lambda_github_webhooks_receive_policy" {
+    name = "lambda-github-webhooks-receive"
+    role = "${aws_iam_role.lambda_github_webhooks_receive.id}"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.lambda_receive.arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "firehose:PutRecord",
+                "firehose:PutRecordBatch"
+            ],
+            "Resource": [
+                "${aws_kinesis_firehose_delivery_stream.webhooks.arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "SNS:Publish"
+            ],
+            "Resource": [
+                "${aws_sns_topic.webhooks_all.arn}",
+                "${aws_sns_topic.webhooks_public.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+# The firehose policy allows:
+# * Writing to CloudWatch
+# * Writing to S3
+
+resource "aws_iam_role" "kinesis_firehose_github_webhooks" {
+    name = "kinesis-firehose-github-webhooks"
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+            "Service": "firehose.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "firehose_github_webhooks" {
+    name = "firehose-github-webhooks-kinesis-firehose"
+    role = "${aws_iam_role.kinesis_firehose_github_webhooks.id}"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.webhooks_bucket.arn}"
+            ]
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.kinesisfirehose_github_webhooks.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+# The Pulse role allows:
+# * Writing to CloudWatch
+
+resource "aws_iam_role" "lambda_github_webhooks_pulse" {
+    name = "lambda-github-webhooks-pulse"
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "lambda_github_webhooks_pulse" {
+    name = "lambda-github-webhooks-pulse"
+    role = "${aws_iam_role.lambda_github_webhooks_pulse.id}"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.lambda_pulse.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/githubwebhooks/init.sh
+++ b/githubwebhooks/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+set -euf -o pipefail
+
+tfenv=$(basename $(pwd))
+
+# Set up remote state
+terraform remote config -backend=s3 \
+    -backend-config="bucket=moz-devservices" \
+    -backend-config="key=tf_state/${tfenv}/terraform.tfstate" \
+    -backend-config="region=us-east-1"
+
+# Update modules
+terraform get

--- a/githubwebhooks/initialize.tf
+++ b/githubwebhooks/initialize.tf
@@ -1,0 +1,1 @@
+../initialize.tf

--- a/githubwebhooks/kinesis.tf
+++ b/githubwebhooks/kinesis.tf
@@ -1,0 +1,16 @@
+resource "aws_kinesis_firehose_delivery_stream" "webhooks" {
+    name = "github-webhooks"
+    destination = "s3"
+    s3_configuration {
+        role_arn = "${aws_iam_role.kinesis_firehose_github_webhooks.arn}"
+        bucket_arn = "${aws_s3_bucket.webhooks_bucket.arn}"
+        buffer_size = 10
+        buffer_interval = 600
+        prefix = "kinesis/"
+        cloudwatch_logging_options {
+            enabled = true
+            log_group_name = "${aws_cloudwatch_log_group.kinesisfirehose_github_webhooks.name}"
+            log_stream_name = "S3Delivery"
+        }
+    }
+}

--- a/githubwebhooks/lambda.tf
+++ b/githubwebhooks/lambda.tf
@@ -1,0 +1,31 @@
+resource "aws_lambda_function" "lambda_receive" {
+    s3_bucket = "${aws_s3_bucket.webhooks_bucket.bucket}"
+    s3_key = "github_lambda.zip"
+    function_name = "github-webhooks-receive"
+    handler = "lambda_receive.handler"
+    role = "${aws_iam_role.lambda_github_webhooks_receive.arn}"
+    description = "Handles incoming GitHub web hooks"
+    runtime = "python2.7"
+    memory_size = 128
+    timeout = 5
+}
+
+resource "aws_lambda_function" "lambda_pulse" {
+    s3_bucket = "${aws_s3_bucket.webhooks_bucket.bucket}"
+    s3_key = "github_lambda.zip"
+    function_name = "github-webhooks-pulse"
+    handler = "lambda_pulse.handler"
+    role = "${aws_iam_role.lambda_github_webhooks_receive.arn}"
+    description = "Publish GitHub web hooks to Pulse"
+    runtime = "python2.7"
+    memory_size = 128
+    timeout = 20
+}
+
+resource "aws_lambda_permission" "allow_api_gateway" {
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.lambda_receive.function_name}"
+    principal = "apigateway.amazonaws.com"
+    statement_id = "AllowExecutionFromApiGateway"
+    source_arn = "arn:aws:execute-api:${var.region}:699292812394:${aws_api_gateway_rest_api.webhooks.id}/*/${aws_api_gateway_integration.webhook_post_lambda.integration_http_method}${aws_api_gateway_resource.webhook.path}"
+}

--- a/githubwebhooks/provider.tf
+++ b/githubwebhooks/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+    region = "${var.region}"
+    profile = "${var.profile}"
+}

--- a/githubwebhooks/resources.tf
+++ b/githubwebhooks/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/githubwebhooks/s3.tf
+++ b/githubwebhooks/s3.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "webhooks_bucket" {
+    bucket = "moz-github-webhooks"
+    acl = "private"
+    tags {
+        App = "GitHub WebHooks"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1170600"
+    }
+}

--- a/githubwebhooks/sns.tf
+++ b/githubwebhooks/sns.tf
@@ -1,0 +1,13 @@
+resource "aws_sns_topic" "webhooks_all" {
+    name = "github-webhooks-all"
+}
+
+resource "aws_sns_topic" "webhooks_public" {
+    name = "github-webhooks-public"
+}
+
+resource "aws_sns_topic_subscription" "public_webhooks_to_pulse" {
+    topic_arn = "${aws_sns_topic.webhooks_public.arn}"
+    protocol = "lambda"
+    endpoint = "${aws_lambda_function.lambda_pulse.arn}"
+}

--- a/githubwebhooks/terraform.tfvars
+++ b/githubwebhooks/terraform.tfvars
@@ -1,0 +1,4 @@
+profile="devservices"
+env="base"
+region="us-west-2"
+key_name="moz-devservices"

--- a/githubwebhooks/variables.tf
+++ b/githubwebhooks/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
This commit implements an environment for GitHub Web Hooks processing.

Details of how everything works are in the README.

I attempted to import existing state from the moz-devservices
account. However, not all items could be imported. I'm tempted
to delete everything from the AWS account and use Terraform
to define everything from a clean slate to make sure it works.

We should probably coordinate on this pull request landing, as I'm
not sure if any of this works. `terraform plan` seems reasonable,
however.
