### PR TITLE
Allow treeherder devs more self-service while protecting production resources

### DIFF
--- a/base/files/treeherder_rds.json
+++ b/base/files/treeherder_rds.json
@@ -2,18 +2,77 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "Stmt1436277160000",
+            "Sid": "DenyRDSFootGuns",
+            "Effect": "Deny",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+                "rds:DeleteDBInstance",
+                "rds:DeleteDBParameterGroup",
+                "rds:DeleteDBSnapshot",
+                "rds:DeleteDBSubnetGroup",
+                "rds:ModifyDBSubnetGroup"
+            ],
+            "Resource": [
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-prod",
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-stage",
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-heroku",
+                "arn:aws:rds:us-east-1:699292812394:pg:treeherder",
+                "arn:aws:rds:us-east-1:699292812394:pg:treeherder-prod",
+                "arn:aws:rds:us-east-1:699292812394:ri:treeherder-prod",
+                "arn:aws:rds:us-east-1:699292812394:ri:treeherder-stage",
+                "arn:aws:rds:us-east-1:699292812394:snapshot:rds:treeherder-prod-*",
+                "arn:aws:rds:us-east-1:699292812394:snapshot:rds:treeherder-stage-*",
+                "arn:aws:rds:us-east-1:699292812394:subgrp:treeherder-dbgrp"
+            ]
+        },
+        {
+            "Sid": "AllowProdDBManage",
             "Effect": "Allow",
             "Action": [
                 "rds:ApplyPendingMaintenanceAction",
                 "rds:CopyDBParameterGroup",
                 "rds:CopyDBSnapshot",
                 "rds:CopyOptionGroup",
+                "rds:CreateEventSubscription",
+                "rds:DeleteEventSubscription",
+                "rds:Describe*",
+                "rds:DownloadCompleteDBLogFile",
+                "rds:DownloadDBLogFilePortion",
+                "rds:ListTagsForResource",
+                "rds:ModifyEventSubscription",
+                "rds:RebootDBInstance"
+            ],
+            "Resource": [
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-prod",
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-stage",
+                "arn:aws:rds:us-east-1:699292812394:pg:treeherder",
+                "arn:aws:rds:us-east-1:699292812394:ri:treeherder-prod",
+                "arn:aws:rds:us-east-1:699292812394:ri:treeherder-stage",
+                "arn:aws:rds:us-east-1:699292812394:snapshot:rds:treeherder-prod-*",
+                "arn:aws:rds:us-east-1:699292812394:snapshot:rds:treeherder-stage-*",
+                "arn:aws:rds:us-east-1:699292812394:subgrp:treeherder-dbgrp"
+            ]
+        },
+        {
+            "Sid": "AllowDevDBManage",
+            "Effect": "Allow",
+            "Action": [
+                "rds:ApplyPendingMaintenanceAction",
+                "rds:AddTagsToResource",
+                "rds:CopyDBParameterGroup",
+                "rds:CopyDBSnapshot",
+                "rds:CopyOptionGroup",
+                "rds:CreateDBInstance",
                 "rds:CreateDBParameterGroup",
                 "rds:CreateDBSnapshot",
                 "rds:CreateEventSubscription",
                 "rds:CreateOptionGroup",
                 "rds:DeleteEventSubscription",
+                "rds:DeleteDBInstance",
+                "rds:DeleteDBParameterGroup",
+                "rds:DeleteDBSnapshot",
+                "rds:DeleteOptionGroup",
                 "rds:Describe*",
                 "rds:DownloadCompleteDBLogFile",
                 "rds:DownloadDBLogFilePortion",
@@ -28,8 +87,13 @@
                 "rds:ResetDBParameterGroup"
             ],
             "Resource": [
-                "arn:aws:rds:us-east-1:699292812394:db:treeherder-*",
-                "arn:aws:rds:us-east-1:699292812394:es:treeherder-*"
+                "arn:aws:rds:us-east-1:699292812394:db:treeherder-dev*",
+                "arn:aws:rds:us-east-1:699292812394:og:treeherder-dev*",
+                "arn:aws:rds:us-east-1:699292812394:pg:treeherder-dev*",
+                "arn:aws:rds:us-east-1:699292812394:snapshot:treeherder-*",
+                "arn:aws:rds:us-east-1:699292812394:es:treeherder-*",
+                "arn:aws:rds:us-east-1:699292812394:ri:treeherder-dev*",
+                "arn:aws:rds:us-east-1:699292812394:subgrp:treeherder-dbgrp"
             ]
         },
         {

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -1,3 +1,4 @@
+# coordinate name change with ../base/files/treeherder_rds.json
 resource "aws_db_subnet_group" "treeherder-dbgrp" {
     name = "treeherder-dbgrp"
     description = "Treeherder DB subnet group"
@@ -15,6 +16,7 @@ resource "aws_db_subnet_group" "treeherder-dbgrp" {
     }
 }
 
+# coordinate name change with ../base/files/treeherder_rds.json
 resource "aws_db_parameter_group" "treeherder-pg" {
     name = "treeherder"
     family = "mysql5.6"


### PR DESCRIPTION
We explicitly deny destructive actions on production and staging related resources,
including tag modification in case we decide to use that in IAM policy conditionals. One
twist is that later we override four actions on subgrp:treeherder-dbgrp, to allow devs
to create and delete temporary dev DB instances. Policy permissions on the AWS side seem
to be a bit obtuse here unfortunately.

The result is that devs will be able to create and delete short lived dev DB instances, 
and parameter and option groups without endangering production.