### PR TITLE
Terraform environment for hg.mo

### DIFF
--- a/hgmo/README.rst
+++ b/hgmo/README.rst
@@ -1,0 +1,11 @@
+hg.mozilla.org
+==============
+
+This directory contains a Terraform environment defining infrastructure
+in support of hg.mozilla.org.
+
+It includes:
+
+* S3 buckets for holding bundles
+* A user for uploading to S3
+* A CloudFront distribution for serving content via a CDN

--- a/hgmo/cloudfront.tf
+++ b/hgmo/cloudfront.tf
@@ -1,0 +1,54 @@
+# Set up a CDN to serve data from S3.
+resource "aws_cloudfront_distribution" "bundles" {
+    aliases = ["hg.cdn.mozilla.net"]
+
+    origin {
+        domain_name = "moz-hg-bundles-us-west-2.s3.amazonaws.com"
+        origin_id = "S3-moz-hg-bundles-us-west-2"
+    }
+
+    enabled = true
+    default_root_object = "index.html"
+    http_version = "http1.1"
+
+    logging_config {
+        bucket = "moz-devservices-logging.s3.amazonaws.com"
+        prefix = "cloudfront/hg-bundles"
+    }
+
+    default_cache_behavior {
+        allowed_methods = ["HEAD", "GET"]
+        cached_methods = ["HEAD", "GET"]
+        min_ttl = 0
+        max_ttl = 31536000
+        default_ttl = 86400
+        target_origin_id = "S3-moz-hg-bundles-us-west-2"
+        viewer_protocol_policy = "https-only"
+
+        forwarded_values {
+            query_string = false
+            cookies {
+                forward = "none"
+            }
+        }
+    }
+
+    restrictions {
+        geo_restriction {
+            restriction_type = "none"
+        }
+    }
+
+    viewer_certificate {
+        iam_certificate_id = "ASCAIRLY6OFDMQHNPMX5I"
+        ssl_support_method = "sni-only"
+        minimum_protocol_version = "TLSv1"
+    }
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1185261"
+    }
+}

--- a/hgmo/iam-roles.tf
+++ b/hgmo/iam-roles.tf
@@ -1,0 +1,150 @@
+# This user is used to upload to S3.
+resource "aws_iam_user" "hgbundler" {
+    name = "hgbundler"
+}
+
+# The following policies govern S3 bundles bucket access.
+#
+# The following policies should be identical and only vary by region.
+# Unfortunately, attempting to reference resources outside the current
+# region is rejected by Amazon, hence the need for multiple policies.
+
+data "aws_iam_policy_document" "hg_bundles_use1" {
+    # Grant bundler user access to upload and modify objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_use1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgbundler.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObjectTorrent",
+            "s3:GetObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_use1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}
+
+data "aws_iam_policy_document" "hg_bundles_usw1" {
+    # Grant bundler user access to upload and modify objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_usw1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgbundler.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObjectTorrent",
+            "s3:GetObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_usw1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}
+
+data "aws_iam_policy_document" "hg_bundles_usw2" {
+    # Grant bundler user access to upload and modify objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_usw2.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgbundler.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObjectTorrent",
+            "s3:GetObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_usw2.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}
+
+data "aws_iam_policy_document" "hg_bundles_euc1" {
+    # Grant bundler user access to upload and modify objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_euc1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgbundler.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObjectTorrent",
+            "s3:GetObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_euc1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}

--- a/hgmo/init.sh
+++ b/hgmo/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+set -euf -o pipefail
+
+tfenv=$(basename $(pwd))
+
+# Set up remote state
+terraform remote config -backend=s3 \
+    -backend-config="bucket=moz-devservices" \
+    -backend-config="key=tf_state/${tfenv}/terraform.tfstate" \
+    -backend-config="region=us-east-1"
+
+# Update modules
+terraform get

--- a/hgmo/initialize.tf
+++ b/hgmo/initialize.tf
@@ -1,0 +1,1 @@
+../initialize.tf

--- a/hgmo/provider.tf
+++ b/hgmo/provider.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+    region = "${var.region}"
+    profile = "${var.profile}"
+}
+
+provider "aws" {
+    alias = "use1"
+    region = "us-east-1"
+}
+
+provider "aws" {
+    alias = "usw1"
+    region = "us-west-1"
+}
+
+provider "aws" {
+    alias = "usw2"
+    region = "us-west-2"
+}
+
+provider "aws" {
+    alias = "euc1"
+    region = "eu-central-1"
+}

--- a/hgmo/resources.tf
+++ b/hgmo/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/hgmo/s3.tf
+++ b/hgmo/s3.tf
@@ -1,0 +1,170 @@
+# Per-region S3 buckets hold bundle objects. Each region should be
+# identically configured except for the per-region differences.
+
+resource "aws_s3_bucket" "hg_bundles_use1" {
+    # Buckets are pinned to a specific region and therefore have to use
+    # an explicit provider for that region.
+    provider = "aws.use1"
+    bucket = "moz-hg-bundles-us-east-1"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1041173"
+    }
+
+    # Serve the auto-generated index when / is requested.
+    website {
+        index_document = "index.html"
+    }
+
+    # Send access logs to S3 so we can audit and monitor.
+    logging {
+        target_bucket = "moz-devservices-logging-us-east-1"
+        target_prefix = "s3/hg-bundles/"
+    }
+
+    # Objects automatically expire after 1 week.
+    lifecycle_rule {
+        enabled = true
+        prefix = ""
+        expiration {
+            days = 7
+        }
+        noncurrent_version_expiration {
+            days = 1
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_bundles_use1" {
+    provider = "aws.use1"
+    bucket = "${aws_s3_bucket.hg_bundles_use1.bucket}"
+    policy = "${data.aws_iam_policy_document.hg_bundles_use1.json}"
+}
+
+resource "aws_s3_bucket" "hg_bundles_usw1" {
+    provider = "aws.usw1"
+    bucket = "moz-hg-bundles-us-west-1"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1041173"
+    }
+
+    website {
+        index_document = "index.html"
+    }
+
+    logging {
+        target_bucket = "moz-devservices-logging-us-west-1"
+        target_prefix = "s3/hg-bundles/"
+    }
+
+    lifecycle_rule {
+        enabled = true
+        prefix = ""
+        expiration {
+            days = 7
+        }
+        noncurrent_version_expiration {
+            days = 1
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_bundles_usw1" {
+    provider = "aws.usw1"
+    bucket = "${aws_s3_bucket.hg_bundles_usw1.bucket}"
+    policy = "${data.aws_iam_policy_document.hg_bundles_usw1.json}"
+}
+
+resource "aws_s3_bucket" "hg_bundles_usw2" {
+    provider = "aws.usw2"
+    bucket = "moz-hg-bundles-us-west-2"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1041173"
+    }
+
+    website {
+        index_document = "index.html"
+    }
+
+    logging {
+        target_bucket = "moz-devservices-logging-us-west-2"
+        target_prefix = "s3/hg-bundles/"
+    }
+
+    # Versioning shouldn't be enabled on this bucket. However, Amazon
+    # won't let us turn it off because it claims a replication policy
+    # is present on the bucket.
+    versioning {
+        enabled = true
+    }
+
+    lifecycle_rule {
+        enabled = true
+        prefix = ""
+        expiration {
+            days = 7
+        }
+        noncurrent_version_expiration {
+            days = 1
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_bundles_usw2" {
+    provider = "aws.usw2"
+    bucket = "${aws_s3_bucket.hg_bundles_usw2.bucket}"
+    policy = "${data.aws_iam_policy_document.hg_bundles_usw2.json}"
+}
+
+resource "aws_s3_bucket" "hg_bundles_euc1" {
+    provider = "aws.euc1"
+    bucket = "moz-hg-bundles-eu-central-1"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1041173"
+    }
+
+    website {
+        index_document = "index.html"
+    }
+
+    logging {
+        target_bucket = "moz-devservices-logging-eu-central-1"
+        target_prefix = "s3/hg-bundles/"
+    }
+
+    lifecycle_rule {
+        enabled = true
+        prefix = ""
+        expiration {
+            days = 7
+        }
+        noncurrent_version_expiration {
+            days = 1
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_bundles_euc1" {
+    provider = "aws.euc1"
+    bucket = "${aws_s3_bucket.hg_bundles_euc1.bucket}"
+    policy = "${data.aws_iam_policy_document.hg_bundles_euc1.json}"
+}

--- a/hgmo/terraform.tfvars
+++ b/hgmo/terraform.tfvars
@@ -1,0 +1,4 @@
+profile="devservices"
+env="hgmo"
+region="us-west-2"
+key_name="moz-devservices"

--- a/hgmo/variables.tf
+++ b/hgmo/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
Previously, infrastructure in support of hg.mozilla.org was manually
created via the AWS Web Console. This commit introduces a Terraform
environment to manage that infrastructure.

It is basically some S3 buckets and a CloudFront distribution.

Some things aren't yet captured by this environment:

* The S3 buckets for logging (they are only currently used by
  hg.mo S3 bucket logging but in theory are generic)
* The credentials for the "hgbundler" user
* The X509 certificate used by the CloudFront distribution

I think those can be deferred to another day.