### PR TITLE
treeherder: create new dev read-replica

### DIFF
--- a/treeherder/outputs.tf
+++ b/treeherder/outputs.tf
@@ -1,6 +1,9 @@
 output "heroku_rds" {
     value = "${aws_db_instance.treeherder-heroku.address}"
 }
+output "dev_rds" {
+    value = "${aws_db_instance.treeherder-dev-rds.address}"
+}
 output "stage_rds" {
     value = "${aws_db_instance.treeherder-stage-rds.address}"
 }

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -74,12 +74,35 @@ resource "aws_db_instance" "treeherder-heroku" {
     db_subnet_group_name = "default"
     vpc_security_group_ids = ["sg-3081fd54", "sg-8b81fdef"]
     tags {
-        Name = "treeherder-dev-rds"
+        Name = "treeherder-proto-rds"
         App = "treeherder"
         Type = "rds"
         Env = "dev"
         Owner = "relops"
         BugID = "1176486"
+    }
+}
+
+resource "aws_db_instance" "treeherder-dev-rds" {
+    identifier = "treeherder-dev"
+    replicate_source_db = "treeherder-heroku"
+    storage_type = "gp2"
+    instance_class = "db.m4.xlarge"
+    maintenance_window = "Sun:08:00-Sun:08:30"
+    multi_az = false
+    port = "3306"
+    publicly_accessible = true
+    parameter_group_name = "treeherder"
+    auto_minor_version_upgrade = false
+    db_subnet_group_name = "${aws_db_subnet_group.treeherder-dbgrp.name}"
+    vpc_security_group_ids = ["${aws_security_group.treeherder_heroku-sg.id}"]
+    tags {
+        Name = "treeherder-dev-rds"
+        App = "treeherder"
+        Type = "rds"
+        Env = "dev"
+        Owner = "relops"
+        BugID = "1309395"
     }
 }
 


### PR DESCRIPTION
The treeherder-heroku RDS instance is in the default VPC so we create a
read-replica in the treeherder VPC that we can promote to master and
migrate traffic to.