### PR TITLE
Delegate 'mozreview.mozops.net' to mozreview aws

### DIFF
--- a/base/route53.tf
+++ b/base/route53.tf
@@ -1,4 +1,19 @@
 # Route53 hosted zone for mozops.net
 resource "aws_route53_zone" "mozops" {
-   name = "mozops.net"
+    name = "mozops.net"
+}
+
+# This NS record delegates the subdomain 'mozreview.mozops.net' to
+# the mozreview aws account.  The authoritative name servers can be
+# queried with the aws cli tools.
+# eg. aws route53 get-hosted-zone --id ZOJF0BEJC8OX3
+resource "aws_route53_record" "mozreview_mozops" {
+    zone_id = "${aws_route53_zone.mozops.zone_id}"
+    name = "mozreview.mozops.net"
+    type = "NS"
+    ttl = "300"
+    records = ["ns-880.awsdns-46.net",
+               "ns-2.awsdns-00.com",
+               "ns-1819.awsdns-35.co.uk",
+               "ns-1522.awsdns-62.org"]
 }


### PR DESCRIPTION
    This commit delegates the subdomain 'mozreview.mozops.net' to the
    mozreview aws account.  There a hosted zone is setup for managing
    RRs within the account.