### PR TITLE
hgmo: SNS topic for repository events

### DIFF
--- a/hgmo/README.rst
+++ b/hgmo/README.rst
@@ -9,3 +9,4 @@ It includes:
 * S3 buckets for holding bundles
 * A user for uploading to S3
 * A CloudFront distribution for serving content via a CDN
+* SNS topic receiving info about events on hg.mozilla.org

--- a/hgmo/sns.tf
+++ b/hgmo/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "events" {
+    name = "hgmo-events"
+    display_name = "Pushes and other repository events on hg.mozilla.org"
+}
+
+resource "aws_sns_topic_policy" "events" {
+    arn = "${aws_sns_topic.events.arn}"
+    policy = "${data.aws_iam_policy_document.sns_subscribe_events.json}"
+}


### PR DESCRIPTION
hg.mo will soon be publishing events to SNS. This defines the
SNS topic, user, and policies to make that happen.