### PR TITLE
treeherder: remove old treeherder-heroku RDS instance and infra

### DIFF
--- a/treeherder/iam.tf
+++ b/treeherder/iam.tf
@@ -64,7 +64,6 @@ data "aws_iam_policy_document" "treeherder_rds" {
         resources = [
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-stage",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-heroku",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-prod",

--- a/treeherder/outputs.tf
+++ b/treeherder/outputs.tf
@@ -1,6 +1,3 @@
-output "heroku_rds" {
-    value = "${aws_db_instance.treeherder-heroku.address}"
-}
 output "dev_rds" {
     value = "${aws_db_instance.treeherder-dev-rds.address}"
 }

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -54,35 +54,6 @@ resource "aws_db_parameter_group" "treeherder-pg" {
     }
 }
 
-resource "aws_db_instance" "treeherder-heroku" {
-    identifier = "treeherder-heroku"
-    storage_type = "gp2"
-    allocated_storage = 500
-    engine = "mysql"
-    engine_version = "5.6.29"
-    instance_class = "db.m4.xlarge"
-    username = "th_admin"
-    backup_retention_period = 1
-    backup_window = "07:00-07:30"
-    maintenance_window = "Sun:08:00-Sun:08:30"
-    multi_az = true
-    port = "3306"
-    publicly_accessible = true
-    parameter_group_name = "treeherder"
-    option_group_name = "default:mysql-5-6"
-    auto_minor_version_upgrade = false
-    db_subnet_group_name = "default"
-    vpc_security_group_ids = ["sg-3081fd54", "sg-8b81fdef"]
-    tags {
-        Name = "treeherder-proto-rds"
-        App = "treeherder"
-        Type = "rds"
-        Env = "dev"
-        Owner = "relops"
-        BugID = "1176486"
-    }
-}
-
 resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "rds:treeherder-prod-2016-11-10-07-05"

--- a/treeherder/vpc.tf
+++ b/treeherder/vpc.tf
@@ -1,53 +1,7 @@
-# original sg for treeherder-heroku rds, in default vpc
-resource "aws_security_group" "treeherder_heroku_sg" {
-    name = "treeherder_heroku_sg"
-    description = "Treeherder Heroku RDS access"
-    vpc_id = "vpc-ccf5aca9"
-    tags {
-        Name = "treeherder_heroku_sg"
-    }
-    tags {
-        Name = "treeherder-dev-sg"
-        App = "treeherder"
-        Type = "sg"
-        Env = "dev"
-        Owner = "relops"
-        BugID = "1176486"
-    }
-}
-resource "aws_security_group_rule" "treeherder_heroku_sg" {
-    type = "ingress"
-    from_port = 3306
-    to_port = 3306
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    security_group_id = "${aws_security_group.treeherder_heroku_sg.id}"
-}
-resource "aws_security_group_rule" "treeherder_heroku_sg-1" {
-    type = "egress"
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    security_group_id = "${aws_security_group.treeherder_heroku_sg.id}"
-}
-
 resource "aws_security_group" "treeherder_heroku-sg" {
     name = "treeherder_heroku-sg"
     description = "Treeherder Heroku RDS access"
     vpc_id = "${aws_vpc.treeherder-vpc.id}"
-    ingress {
-        from_port = 8
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = ["10.0.0.0/8"]
-    }
-    ingress {
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
     ingress {
         from_port = 3306
         to_port = 3306


### PR DESCRIPTION
Remove the old treeherder-heroku RDS instance and associated security
groups/rules, and remove it from the IAM policy.

Also pull SSH and ICMP access in the remaining security group for
dev/stage/prod as it's no longer needed.

https://bugzilla.mozilla.org/show_bug.cgi?id=1309395#c16