### PR TITLE
hgmo: s3 bucket for holding events (bug 1316952)

### DIFF
--- a/hgmo/iam-roles.tf
+++ b/hgmo/iam-roles.tf
@@ -191,3 +191,36 @@ data "aws_iam_policy_document" "sns_subscribe_events" {
         }
     }
 }
+
+data "aws_iam_policy_document" "s3_hg_events_usw2" {
+    # Grant notifier user access to upload objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObject",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_events_usw2.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgnotifier.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_events_usw2.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}

--- a/hgmo/s3.tf
+++ b/hgmo/s3.tf
@@ -168,3 +168,29 @@ resource "aws_s3_bucket_policy" "hg_bundles_euc1" {
     bucket = "${aws_s3_bucket.hg_bundles_euc1.bucket}"
     policy = "${data.aws_iam_policy_document.hg_bundles_euc1.json}"
 }
+
+# Bucket to hold data about replication events.
+
+resource "aws_s3_bucket" "hg_events_usw2" {
+    provider = "aws.usw2"
+    bucket = "moz-hg-events-us-west-2"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1316952"
+    }
+
+    logging = {
+        target_bucket = "moz-devservices-logging-us-west-2"
+        target_prefix = "s3/hg-events/"
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_events_usw2" {
+    provider = "aws.usw2"
+    bucket = "${aws_s3_bucket.hg_events_usw2.bucket}"
+    policy = "${data.aws_iam_policy_document.s3_hg_events_usw2.json}"
+}


### PR DESCRIPTION
We want hg.mo to write a stream of log events to S3 for data
retention and for reference by other services. Some events are on
the larger side and exceed size limits in SNS and Kinesis Firehose.
So, we'll write all events to S3 and then reference the object URL
in SNS/Kinesis/etc events if the event is too large to fit in a payload.

This commit introduces an S3 bucket and policy to hold hg.mo
events. The hgnotifier user can write to the bucket. Anybody can
read from the bucket (because all data is public and already posted
to Pulse).