### PR TITLE
treeherder: Increase stage RDS storage to 750GB (bug 1330738)

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -80,7 +80,7 @@ resource "aws_db_instance" "treeherder-dev-rds" {
 resource "aws_db_instance" "treeherder-stage-rds" {
     identifier = "treeherder-stage"
     storage_type = "gp2"
-    allocated_storage = 500
+    allocated_storage = 750
     engine = "mysql"
     engine_version = "5.6.29"
     instance_class = "db.m4.xlarge"


### PR DESCRIPTION
To increase the baseline general storage performance from 1500 IOPS to 2250 IOPS, for parity with the production RDS instance and to help alleviate load on stage.