### PR TITLE
treeherder: Update dev/stage from MySQL 5.6.29 to 5.6.34 (bug 1330743)

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -58,6 +58,8 @@ resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "rds:treeherder-prod-2017-01-18-07-05"
     storage_type = "gp2"
+    engine = "mysql"
+    engine_version = "5.6.34"
     instance_class = "db.m4.xlarge"
     maintenance_window = "Sun:08:00-Sun:08:30"
     multi_az = false
@@ -82,7 +84,7 @@ resource "aws_db_instance" "treeherder-stage-rds" {
     storage_type = "gp2"
     allocated_storage = 750
     engine = "mysql"
-    engine_version = "5.6.29"
+    engine_version = "5.6.34"
     instance_class = "db.m4.xlarge"
     username = "th_admin"
     password = "XXXXXXXXXXXXXXXX"


### PR DESCRIPTION
It wasn't clear from the [Terraform RDS docs](https://www.terraform.io/docs/providers/aws/r/db_instance.html) whether it was allowed to put both a `snapshot_identifier` and an `engine_version`, but looking at the source it seems fine:
https://github.com/hashicorp/terraform/blob/c5f899d64ce418ae9f472ba9ad97d470b151ab36/builtin/providers/aws/resource_aws_db_instance.go#L391-L416