### PR TITLE
Output key bucket and key policy arn

### DIFF
--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -25,3 +25,11 @@ output "manage_creds_arn" {
 output "access_support_arn" {
     value = "${aws_iam_policy.access_support.arn}"
 }
+
+output "ec2_read_ssh_keys_policy_arn" {
+    value = "${aws_iam_instance_profile.ec2-read-ssh-keys.arn}"
+}
+
+output "key_bucket_id" {
+    value = "${aws_s3_bucket.key_bucket.id}"
+}


### PR DESCRIPTION
Exporting the key bucket name and the profile arn to read said bucket.  This also the evaluation of:

${data.terraform_remote_state.base.ec2_read_ssh_keys_policy_arn}

and 

${data.terraform_remote_state.base.key_bucket_id}
