### PR TITLE
treeherder: Use READ-COMMITTED MySQL tx_isolation level (bug 1330324)

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -45,6 +45,10 @@ resource "aws_db_parameter_group" "treeherder-pg" {
         name = "sql_mode"
         value = "NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
     }
+    parameter {
+        name = "tx_isolation"
+        value = "READ-COMMITTED"
+    }
     tags {
         Name = "treeherder-prod-pg"
         App = "treeherder"


### PR DESCRIPTION
Since Django recommends it over REPEATABLE-READ:
https://docs.djangoproject.com/en/1.10/ref/models/querysets/#get-or-create
https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_tx_isolation

This is the stage/prod RDS equivalent of:
https://github.com/mozilla/treeherder/pull/2173