### PR TITLE
vcssync: define CloudWatch log group (bug 1364231)

### DIFF
--- a/vcssync/cloudwatch.tf
+++ b/vcssync/cloudwatch.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudwatch_log_group" "vcssync" {
+    name = "/vcssync"
+    retention_in_days = 30
+    tags = {
+        App = "VCS Sync"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1364231"
+    }
+}


### PR DESCRIPTION
We add a CloudWatch log group for vcssync. The IAM policy document
for the EC2 instance has been modified to grant permissions to
write to and get metadata for the log group.