### PR TITLE
githubwebhooks: declare environment variables for Pulse

### DIFF
--- a/githubwebhooks/README.rst
+++ b/githubwebhooks/README.rst
@@ -25,3 +25,33 @@ The Lambda functions are defined in the version-control-tools
 repository. That repository has its own code for uploading a new
 version of the execution environment and triggering a refresh of the
 Lambda environment.
+
+Configuring Secret Variables
+============================
+
+The ``github-webhooks-pulse`` Lambda function has user credentials for Pulse
+defined in environment variables. These credentials can't be checked into
+this repository.
+
+When running ``terraform``, you may be prompted for these credentials.
+
+To avoid being prompted, you can define these variables in an offline
+file. The content of that file would look something like::
+
+    pulse_user = "<username>"
+    pulse_password = "<password>"
+
+.. hint::
+
+   If you view the Lambda function in the AWS web console, the username and
+   password will be printed in plain text in the ``Environment variables``
+   section of the ``Code`` tab.
+
+Then, pass ``-var-file`` to ``terraform`` to tell it to load that variables
+file. e.g.
+
+   $ terraform plan -var-file ~/.tf_githubwebhooks.tfvars
+
+If the credentials are defined properly and you haven't made any
+Terraform changes, that above command should not prompt you for credentials
+and should say there are no changes to be made.

--- a/githubwebhooks/lambda.tf
+++ b/githubwebhooks/lambda.tf
@@ -10,6 +10,16 @@ resource "aws_lambda_function" "lambda_receive" {
     timeout = 5
 }
 
+variable "pulse_user" {
+    type = "string"
+    description = "Pulse username"
+}
+
+variable "pulse_password" {
+    type = "string"
+    description = "Pulse password"
+}
+
 resource "aws_lambda_function" "lambda_pulse" {
     s3_bucket = "${aws_s3_bucket.webhooks_bucket.bucket}"
     s3_key = "github_lambda.zip"
@@ -20,6 +30,13 @@ resource "aws_lambda_function" "lambda_pulse" {
     runtime = "python2.7"
     memory_size = 128
     timeout = 20
+    environment {
+        variables {
+            PULSE_EXCHANGE = "exchange/github-webhooks/v1"
+            PULSE_USER = "${var.pulse_user}"
+            PULSE_PASSWORD = "${var.pulse_password}"
+        }
+    }
 }
 
 resource "aws_lambda_permission" "allow_api_gateway" {


### PR DESCRIPTION
I ran `terraform plan` locally and Terraform wanted to wipe out
some environment variables for the github-webhooks-pulse Lambda
function. I guess someone (probably me) defined these environment
variables in the AWS web console.

This commit adds those environment variables to Terraform and
documents how they should be locally defined.