### PR TITLE
Bug 1374380 - Temporary hostname for build metrics ingestion

### DIFF
--- a/base/route53.tf
+++ b/base/route53.tf
@@ -24,3 +24,16 @@ resource "aws_route53_record" "mozreview_mozops" {
                "ns-1819.awsdns-35.co.uk",
                "ns-1522.awsdns-62.org"]
 }
+
+# This record is used by a server that receives Firefox build
+# system metrics. The record should be temporary until more permanent
+# ingestion is stood up. Tracked in bug 1242017.
+resource "aws_route53_record" "build_metrics_ingest" {
+    zone_id = "${aws_route53_zone.mozops.zone_id}"
+    name = "build-metrics-ingest.mozops.net"
+    type = "A"
+    ttl = "60"
+    # This is an AWS instance maintained by ekyle in a separate
+    # AWS account.
+    records = ["54.149.253.188"]
+}


### PR DESCRIPTION
This is meant to be temporary (weeks to months). Name was chosen
somewhat arbitrarily. The service this is related to doesn't
have a presence in our AWS account. So there was no obvious file
to define the record in. Since it is meant to be temporary,
I just put it in the base "profile."