### PR TITLE
Update jumphost configuration

### DIFF
--- a/base/ec2-jumphosts.tf
+++ b/base/ec2-jumphosts.tf
@@ -1,7 +1,20 @@
 # NOTE:
 # Region specific resources make use of a "provider alias" to override the base setting
 
+data "template_file" "jh_user_data" {
+    template = "${file("files/user_data.tmpl")}"
+    vars {
+        s3_bucket = "${var.base_bucket}"
+        addl_user_data = "ssh-pubkeys,associate-eip,set_sysctl"
+    }
+}
+
 #---[ US-EAST-1 ]---
+resource "aws_eip" "jumphost_use1_eip" {
+    provider = "aws.us-east-1"
+    vpc = true
+}
+
 resource "aws_launch_configuration" "jumphost_use1_lc" {
     provider = "aws.us-east-1"
     name_prefix = "jumphost_use1_lc-"
@@ -9,8 +22,8 @@ resource "aws_launch_configuration" "jumphost_use1_lc" {
     image_id = "${lookup(var.centos7_amis,"us-east-1")}"
     key_name = "${var.key_name}"
     security_groups = ["${aws_security_group.jumphost_use1_sg.id}"]
-    iam_instance_profile = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/ec2-read-ssh-keys"
-    user_data = "${file("files/jumphost-userdata.sh")}"
+    iam_instance_profile = "${aws_iam_instance_profile.ec2_manage_eip-profile.arn}"
+    user_data = "${data.template_file.jh_user_data.rendered}"
     lifecycle {
         create_before_destroy = true
     }
@@ -50,6 +63,11 @@ resource "aws_autoscaling_group" "jumphost_use1_asg" {
     tag {
         key = "Owner"
         value = "relops"
+        propagate_at_launch = true
+    }
+    tag {
+        key = "EIP"
+        value = "${aws_eip.jumphost_use1_eip.public_ip}"
         propagate_at_launch = true
     }
 }

--- a/base/files/ec2-manage-EIP.json
+++ b/base/files/ec2-manage-EIP.json
@@ -1,0 +1,13 @@
+{
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AssociateAddress",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeTags"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/base/files/s3_base_bucket.json.tmpl
+++ b/base/files/s3_base_bucket.json.tmpl
@@ -1,0 +1,40 @@
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowEC2ToReadBaseBucket",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::${account_id}:role/${ec2_assume_role}",
+                    "arn:aws:iam::${account_id}:role/${ec2_manage_eip_role}"
+                ]
+            },
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::${key_bucket}"
+        },
+        {
+            "Sid": "AllowEC2ToReadBaseBucketObjects",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::${account_id}:role/${ec2_assume_role}",
+                    "arn:aws:iam::${account_id}:role/${ec2_manage_eip_role}"
+                ]
+            },
+            "Action": [
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Resource": "arn:aws:s3:::${key_bucket}/*"
+        },
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": "arn:aws:s3:::${key_bucket}/repos/*"
+        }
+    ]
+}

--- a/base/files/user-data/associate-eip
+++ b/base/files/user-data/associate-eip
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Caveat: any variable inside curly braces will be interpolated by terraform!
+#
+# Create and run script to associate Elastic IP
+
+## Install aws-ec2-assign-elastic-ip
+pip install --upgrade aws-ec2-assign-elastic-ip
+
+mkdir -p /root/bin
+
+# Create EIP associate script
+EIP_SCRIPT="/root/bin/associate_eip.sh"
+
+# ---[ start of script creation ]---
+cat <<EOF > $EIP_SCRIPT
+#!/usr/bin/env bash
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+VALID_IPS=\$(aws --output json --region \$REGION ec2 describe-tags --filters "Name=resource-id,Values=\$INSTANCE_ID" "Name=key,Values=EIP" | jq -r '.Tags[].Value')
+
+aws-ec2-assign-elastic-ip --region \$REGION --valid-ips \$VALID_IPS
+
+EOF
+# ---[ end of script creation ]---
+
+## Set perms
+chmod 755 $EIP_SCRIPT
+
+## Run script
+$EIP_SCRIPT

--- a/base/files/user-data/attach-vol
+++ b/base/files/user-data/attach-vol
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Caveat: any variable inside curly braces will be interpolated by terraform!
+#
+# Create and run script to attach and mount an EBS volume
+
+mkdir -p /root/bin
+
+# Create script
+SCRIPT="/root/bin/attach_vol.sh"
+
+# ---[ start of script creation ]---
+cat <<EOF > $SCRIPT
+#!/usr/bin/env bash
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+MOUNT=\$(aws --output json ec2 describe-tags --filters "Name=resource-id,Values=\$INSTANCE_ID" "Name=key,Values=MountPoint" | jq -r '.Tags[].Value')
+
+# this assumes root device is sda or xvda
+DEV=\$(lsblk -drn -o NAME | grep -v 'da$')
+
+FILE=\$(file -s /dev/\$DEV | awk '{print \$2}')
+if [ "\$FILE" == "data" ]; then
+    mkfs -t ext4 /dev/\$DEV
+fi
+
+mkdir -p \$MOUNT
+chmod 755 \$MOUNT
+
+echo "/dev/\$DEV \$MOUNT ext4 defaults 0 2" >> /etc/fstab
+
+mount \$MOUNT
+
+# requires IAM role permissions
+#aws ec2 attach-volume --volume-id \$VOLUME --instance-id \$INSTANCE_ID --device /dev/xvdg
+#echo "/dev/xvdg /mount_pt ext4 defaults,nofail 0 2" >> /etc/fstab
+#mount -av
+
+EOF
+# ---[ end of script creation ]---
+
+## Set perms
+chmod 755 $SCRIPT
+
+## Run script
+$SCRIPT

--- a/base/files/user-data/set_sysctl
+++ b/base/files/user-data/set_sysctl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Caveat: any variable inside curly braces will be interpolated by terraform!
+#
+# Create and run script to set global sysctl variables
+
+mkdir -p /root/bin
+
+# Create sysctl script
+SYSCTL_SCRIPT="/root/bin/set_sysctl.sh"
+
+# ---[ start of script creation ]---
+cat <<EOF > $SYSCTL_SCRIPT
+#!/usr/bin/env bash
+
+# See Bug 1294125
+sysctl -w net.ipv4.tcp_challenge_ack_limit=999999999
+echo "net.ipv4.tcp_challenge_ack_limit = 999999999" > /etc/sysctl.d/tcp_challenge_ack
+
+EOF
+# ---[ end of script creation ]---
+
+## Set perms
+chmod 755 $SYSCTL_SCRIPT
+
+## Run script
+$SYSCTL_SCRIPT

--- a/base/files/user-data/ssh-pubkeys.tmpl
+++ b/base/files/user-data/ssh-pubkeys.tmpl
@@ -1,0 +1,69 @@
+aveat: any variable inside curly braces will be interpolated by terraform!
+#
+# Create script and cron job to auto-update SSH pub keys
+
+## determine SSH_USER
+if [ -f /etc/centos-release ]; then
+    SSH_USER="centos"
+elif [ -f /etc/redhat-release ]; then
+    SSH_USER="ec2-user"
+elif [ -f /etc/debian_version ]; then
+    SSH_USER="ubuntu"
+fi
+
+mkdir /home/$SSH_USER/bin
+
+# Create SSH pub keys update script
+SSH_SCRIPT="/home/$SSH_USER/bin/update_ssh_keys.sh"
+
+# ---[ start of script creation ]---
+cat <<EOF > $SSH_SCRIPT
+#!/usr/bin/env bash
+BUCKET="${base_bucket}"
+PREFIX="${pubkey_bucket_prefix}"
+MARKER="# KEYS_BELOW_WILL_BE_UPDATED_BY_TERRAFORM"
+
+umask 0077
+cd ~/.ssh
+
+## Fetch keys
+if [ -d pub_key_files ]; then
+    rm -rf pub_key_files
+else
+    mkdir pub_key_files
+fi
+for path in \$(aws s3api list-objects --bucket \$BUCKET --prefix \$PREFIX | jq -r '.Contents[].Key')
+do
+    aws s3 cp s3://\$BUCKET/\$path pub_key_files/ > /dev/null
+done
+
+## Set marker
+if ! grep -Fxq "\$MARKER" authorized_keys;
+then
+  echo "\$MARKER" >> authorized_keys
+fi
+
+## Truncate to marker, append new keys, using temp file
+sed "/^\$MARKER/q" authorized_keys > authorized_keys.new
+for f in pub_key_files/*
+do
+    (cat "\$f"; echo) >> authorized_keys.new
+done
+sed -i '/^$/d' authorized_keys.new
+
+mv authorized_keys.new authorized_keys
+EOF
+# ---[ end of script creation ]---
+
+## Set perms
+chmod 755 $SSH_SCRIPT
+
+## Run script
+su $SSH_USER -c $SSH_SCRIPT
+
+## Add cronjob
+# centos crontab doesn't allow STDIN input
+if [ ! -f /etc/cron.d/update-ssh-keys ]; then
+    echo "*/10 * * * * $SSH_USER $SSH_SCRIPT" > /etc/cron.d/update-ssh-keys
+    chmod 644 /etc/cron.d/update-ssh-keys
+fi

--- a/base/files/user_data.tmpl
+++ b/base/files/user_data.tmpl
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Caveat: any variable inside curly braces will be interpolated by terraform!
+# 
+# Sets up YUM EPEL repo, installs prereqs
+
+BUCKET=${s3_bucket}
+ADDL_USER_DATA=${addl_user_data}
+
+function epel_bootstrap() {
+    cat <<EOM > /etc/yum.repos.d/epel-bootstrap.repo
+[epel]
+name=Bootstrap EPEL
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-\$releasever&arch=\$basearch
+failovermethod=priority
+enabled=0
+gpgcheck=0
+EOM
+    yum --enablerepo=epel -y install epel-release
+    rm -f /etc/yum.repos.d/epel-bootstrap.repo
+}
+
+## Test for OS, install dependencies
+if [ -f /etc/centos-release ]; then
+    epel_bootstrap
+    yum update -y
+    yum install -y python-pip jq curl
+elif [ -f /etc/redhat-release ]; then
+    epel_bootstrap
+    yum update -y
+    yum install -y python-pip jq curl
+elif [ -f /etc/debian_version ]; then
+    apt-get update -y
+    apt-get install -y python-pip jq curl
+fi
+
+## Install awscli
+pip install --upgrade awscli
+
+TMPDIR=$(mktemp -d)
+
+for SCRIPT in $(echo "$ADDL_USER_DATA" | tr , ' ')
+do
+    aws s3 cp s3://$BUCKET/user-data/$SCRIPT $TMPDIR
+    chmod 755 $TMPDIR/$SCRIPT
+    $TMPDIR/$SCRIPT
+done

--- a/base/iam-roles.tf
+++ b/base/iam-roles.tf
@@ -23,6 +23,19 @@ resource "aws_iam_role_policy" "ec2-read-s3-keys" {
     policy = "${file("files/ec2-read-s3-keys.json")}"
 }
 
+# Allow bastion hosts to AssumeRole
+resource "aws_iam_role" "ec2_manage_eip-role" {
+    name = "ec2_manage_eip"
+    assume_role_policy = "${file("files/ec2-assume-role.json")}"
+}
+
+# Allow bastion hosts to manage their Elastic IP
+resource "aws_iam_role_policy" "ec2_manage_eip-policy" {
+    name = "ec2_manage_eip-policy"
+    role = "${aws_iam_role.ec2_manage_eip-role.id}"
+    policy = "${file("files/ec2-manage-EIP.json")}"
+}
+
 # RDS role to send enhanced monitoring to CloudWatch
 # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html
 resource "aws_iam_role" "rds-monitoring-role" {

--- a/base/iam-roles.tf
+++ b/base/iam-roles.tf
@@ -36,6 +36,12 @@ resource "aws_iam_role_policy" "ec2_manage_eip-policy" {
     policy = "${file("files/ec2-manage-EIP.json")}"
 }
 
+# Create instance profile for bastion hosts to manage EIP
+resource "aws_iam_instance_profile" "ec2_manage_eip-profile" {
+    name = "ec2_manage_eip"
+    role = "${aws_iam_role.ec2_manage_eip-role.name}"
+}
+
 # RDS role to send enhanced monitoring to CloudWatch
 # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html
 resource "aws_iam_role" "rds-monitoring-role" {

--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -13,6 +13,9 @@ output "allow_usw2_jumphost_sg_id" {
 output "jumphost_usw2_sg" {
     value = "${aws_security_group.jumphost_usw2_sg.name}"
 }
+output "jumphost_use1_eip" {
+    value = "${aws_eip.jumphost_use1_eip.public_ip}"
+}
 
 # mozops.net hosted zone ID
 output "mozops_route53_zone_id" {

--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -10,11 +10,11 @@ output "allow_use1_jumphost_sg_id" {
 output "allow_usw2_jumphost_sg_id" {
     value = "${aws_security_group.jumphost_usw2_sg.id}"
 }
-output "jumphost_usw2_sg" {
-    value = "${aws_security_group.jumphost_usw2_sg.name}"
-}
 output "jumphost_use1" {
     value = "${aws_route53_record.jumphost_use1_devservices_mozops_net.name}"
+}
+output "jumphost_usw2" {
+    value = "${aws_route53_record.jumphost_usw2_devservices_mozops_net.name}"
 }
 
 # mozops.net hosted zone ID

--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -13,8 +13,8 @@ output "allow_usw2_jumphost_sg_id" {
 output "jumphost_usw2_sg" {
     value = "${aws_security_group.jumphost_usw2_sg.name}"
 }
-output "jumphost_use1_eip" {
-    value = "${aws_eip.jumphost_use1_eip.public_ip}"
+output "jumphost_use1" {
+    value = "${aws_route53_record.jumphost_use1_devservices_mozops_net.name}"
 }
 
 # mozops.net hosted zone ID

--- a/base/route53.tf
+++ b/base/route53.tf
@@ -52,3 +52,11 @@ resource "aws_route53_record" "build_metrics_ingest" {
     # AWS account.
     records = ["54.149.253.188"]
 }
+
+resource "aws_route53_record" "jumphost_use1_devservices_mozops_net" {
+    zone_id = "${aws_route53_zone.devservices.zone_id}"
+    name = "jumphost.use1.devservices.mozops.net"
+    type = "A"
+    ttl = "60"
+    records = ["${aws_eip.jumphost_use1_eip.public_ip}"]
+}

--- a/base/route53.tf
+++ b/base/route53.tf
@@ -60,3 +60,10 @@ resource "aws_route53_record" "jumphost_use1_devservices_mozops_net" {
     ttl = "60"
     records = ["${aws_eip.jumphost_use1_eip.public_ip}"]
 }
+resource "aws_route53_record" "jumphost_usw2_devservices_mozops_net" {
+    zone_id = "${aws_route53_zone.devservices.zone_id}"
+    name = "jumphost.usw2.devservices.mozops.net"
+    type = "A"
+    ttl = "60"
+    records = ["${aws_eip.jumphost_usw2_eip.public_ip}"]
+}

--- a/base/route53.tf
+++ b/base/route53.tf
@@ -10,6 +10,21 @@ resource "aws_route53_zone" "mozops" {
     }
 }
 
+# Create subdomain for 'devservices.mozops.net'
+resource "aws_route53_zone" "devservices" {
+    name = "devservices.mozops.net"
+}
+resource "aws_route53_record" "devservices_mozops" {
+    zone_id = "${aws_route53_zone.mozops.zone_id}"
+    name = "devservices.mozops.net"
+    type = "NS"
+    ttl = "30"
+    records = ["${aws_route53_zone.devservices.name_servers.0}",
+               "${aws_route53_zone.devservices.name_servers.1}",
+               "${aws_route53_zone.devservices.name_servers.2}",
+               "${aws_route53_zone.devservices.name_servers.3}"]
+}
+
 # This NS record delegates the subdomain 'mozreview.mozops.net' to
 # the mozreview aws account.  The authoritative name servers can be
 # queried with the aws cli tools.

--- a/base/s3.tf
+++ b/base/s3.tf
@@ -46,9 +46,6 @@ resource "aws_s3_bucket_policy" "keys_bucket" {
     policy = "${data.aws_iam_policy_document.s3-ssh-keys-access.json}"
 }
 
-variable "ssh_key_names" {
-    default = "gszorc1,gszorc2,hwine1,klibby2,bjones,gszorc3,jwatkins1,smacleod1"
-}
 resource "aws_s3_bucket_object" "ssh_keys" {
     bucket = "${aws_s3_bucket.key_bucket.bucket}"
     key = "${element(split(",", var.ssh_key_names), count.index)}.pub"

--- a/base/s3.tf
+++ b/base/s3.tf
@@ -2,7 +2,7 @@
 data "template_file" "base_bucket-template" {
     template = "${file("files/s3_base_bucket.json.tmpl")}"
     vars {
-        account_id = "${var.account_id}"
+        account_id = "${data.aws_caller_identity.current.account_id}"
         key_bucket = "${var.base_bucket}"
         ec2_assume_role = "${aws_iam_role.ec2-assume-role.name}"
         ec2_manage_eip_role = "${aws_iam_role.ec2_manage_eip-role.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,14 @@ variable "vpc_map" {
         treeherder-vpc = "10.191.3.0/24"
     }
 }
+
+variable "user_data_scripts" {
+    description = "List of user-data scripts to manage in S3 bucket"
+    default = "associate-eip,attach-vol,set_sysctl"
+    # ssh-pubkeys.tmpl handled via template_file resource in base/s3.tf
+}
+
+variable "ssh_key_names" {
+    description = "List of SSH pub keys to manage in S3 bucket"
+    default = "gszorc1,gszorc2,hwine1,klibby2,bjones,gszorc3,jwatkins1,smacleod1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,11 @@ variable "user_data_scripts" {
     # ssh-pubkeys.tmpl handled via template_file resource in base/s3.tf
 }
 
+variable "pubkey_bucket_prefix" {
+    description = "S3 bucket prefix for pubkeys in base_bucket"
+    default = "pubkeys"
+}
+
 variable "ssh_key_names" {
     description = "List of SSH pub keys to manage in S3 bucket"
     default = "gszorc1,gszorc2,hwine1,klibby2,bjones,gszorc3,jwatkins1,smacleod1"


### PR DESCRIPTION
Import a number of improvements from the mozreview-infra config, using the chained
user-data scripts and new IAM permissions. This allows the jumphost to associate an
EIP, which allows us to use real DNS.