### PR TITLE
treeherder: Update IAM permissions to allow restoring snapshots

### DIFF
--- a/treeherder/iam.tf
+++ b/treeherder/iam.tf
@@ -136,9 +136,9 @@ data "aws_iam_policy_document" "treeherder_rds" {
         ]
         resources = [
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-dev*",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:og:treeherder-dev*",
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:og:default:mysql-5-6",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-dev*",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:snapshot:treeherder-*",
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:snapshot:rds:treeherder-*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:es:treeherder-*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-dev*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:subgrp:treeherder-dbgrp"


### PR DESCRIPTION
The Treeherder RDS instances use the default AWS option group (the previously named `og:treeherder-dev*` does not exist).

In addition, I believe the snapshot permission was incorrectly named, since it doesn't match the similar entries in the `AllowProdDBManage` section, nor the snapshots name listing in AWS console.

Fixes:
https://bugzilla.mozilla.org/show_bug.cgi?id=1309874