### PR TITLE
Bug 1378573 - Allow setting PG on dev db instances

### DIFF
--- a/treeherder/iam.tf
+++ b/treeherder/iam.tf
@@ -145,6 +145,16 @@ data "aws_iam_policy_document" "treeherder_rds" {
         ]
     }
     statement {
+        sid = "AllowDevDBManagePG"
+        effect = "Allow"
+        actions = [
+            "rds:ModifyDBInstance",
+        ]
+        resources = [
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder*",
+        ]
+    }
+    statement {
         effect = "Allow"
         actions = [
             "iam:ListAttachedUserPolicies",


### PR DESCRIPTION
This should allow a user that created a dev db instance to set it to the correct parameter group.