### PR TITLE
treeherder: Upgrade treeherder-dev to MySQL 5.7

### DIFF
--- a/treeherder/iam.tf
+++ b/treeherder/iam.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "treeherder_rds" {
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-stage",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-prod",
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-mysql57",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-stage",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:snapshot:rds:treeherder-prod",
@@ -93,8 +93,7 @@ data "aws_iam_policy_document" "treeherder_rds" {
         resources = [
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-prod*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-stage*",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-prod",
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-stage",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:snapshot:rds:treeherder-prod",
@@ -136,7 +135,7 @@ data "aws_iam_policy_document" "treeherder_rds" {
         ]
         resources = [
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-dev*",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:og:default:mysql-5-6",
+            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:og:default:*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-dev*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:snapshot:rds:treeherder-*",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:es:treeherder-*",

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -58,18 +58,60 @@ resource "aws_db_parameter_group" "treeherder-pg" {
     }
 }
 
+# coordinate name change with aws_iam_policy_document.treeherder_rds in iam.tf
+resource "aws_db_parameter_group" "treeherder-pg-mysql57" {
+    name = "treeherder-mysql57"
+    family = "mysql5.7"
+    description = "Treeherder parameter group for MySQL 5.7"
+    parameter {
+        name = "character_set_server"
+        value = "utf8"
+    }
+    parameter {
+        name = "collation_server"
+        value = "utf8_bin"
+    }
+    parameter {
+        name = "log_output"
+        value = "FILE"
+    }
+    parameter {
+        name = "long_query_time"
+        value = "2"
+    }
+    parameter {
+        name = "slow_query_log"
+        value = "1"
+    }
+    parameter {
+        name = "sql_mode"
+        value = "NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
+    }
+    parameter {
+        name = "tx_isolation"
+        value = "READ-COMMITTED"
+    }
+    tags {
+        Name = "treeherder-prod-pg-mysql57"
+        App = "treeherder"
+        Type = "pg"
+        Env = "prod"
+        Owner = "relops"
+    }
+}
+
 resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "rds:treeherder-prod-2017-01-24-07-06"
     storage_type = "gp2"
     engine = "mysql"
-    engine_version = "5.6.34"
+    engine_version = "5.7.17"
     instance_class = "db.m4.xlarge"
     maintenance_window = "Sun:08:00-Sun:08:30"
     multi_az = false
     port = "3306"
     publicly_accessible = true
-    parameter_group_name = "treeherder"
+    parameter_group_name = "${aws_db_parameter_group.treeherder-pg-mysql57.name}"
     auto_minor_version_upgrade = false
     db_subnet_group_name = "${aws_db_subnet_group.treeherder-dbgrp.name}"
     vpc_security_group_ids = ["${aws_security_group.treeherder_heroku-sg.id}"]


### PR DESCRIPTION
The RDS parameter groups are major-version specific, so a new PG has been created which is otherwise identical to the previous one (the MySQL 5.6 PG will be deleted once all environments have been upgraded).

Also switches to referring to the parameter group via interpolations, since otherwise Terraform won't know of the dependency when determining the execution order.

IAM references to the non-existent `treeherder-prod` parameter group have been removed.

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1378433