### PR TITLE
Add some tests and a Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+dist: trusty
+lang: bash
+
+env:
+  # Whilst this directory is already on PATH, it's after /usr/bin/local.
+  # This prevents the older shellcheck in /usr/bin/local being used instead.
+  - PATH="$HOME/bin:$PATH"
+install:
+  - curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip"
+  - unzip /tmp/terraform.zip -d "$HOME/bin"
+  - terraform --version
+  - curl -sSfL "https://storage.googleapis.com/shellcheck/shellcheck-v0.4.6.linux.x86_64.tar.xz" | tar -xJ --strip-components=1 -C "$HOME/bin"
+  - shellcheck --version
+script:
+  - ./runtests.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 DevServices AWS Account Configuration
 =============================================
 
+[![Build Status](https://travis-ci.org/mozilla-platform-ops/devservices-aws.svg?branch=master)](https://travis-ci.org/mozilla-platform-ops/devservices-aws)
+
 https://moz-devservices.signin.aws.amazon.com/console
 
 Requirements
@@ -9,6 +11,7 @@ Requirements
 - AWS CLI
 - AWS credentials
 - (optional) [MFA helper scripts](https://github.com/mozilla-platform-ops/aws\_mfa\_scripts)
+- (optional) [Shellcheck](https://github.com/koalaman/shellcheck)
 
 Layout
 ------
@@ -29,6 +32,13 @@ Each environment will have a variety of terraform configuration files; they are 
 split up by AWS resource type to make it easier to read and find things. Additionally, 
 there should be an `init.sh` script which will configure terraform remote state for the
 environment and update any modules in use.
+
+Testing
+-------
+To test changes locally ensure Terraform and Shellcheck are on the PATH, then run:
+```bash
+$ ./runtests
+```
 
 Working with remote state
 -------------------------

--- a/init.sh
+++ b/init.sh
@@ -2,7 +2,7 @@
 #
 set -euf -o pipefail
 
-tfenv=$(basename $(pwd))
+tfenv="$(basename "$(pwd)")"
 
 # Set up remote state
 terraform remote config -backend=s3 \

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This is inspired by:
+# https://github.com/travis-infrastructure/terraform-config/blob/master/runtests
+
+set -euo pipefail
+
+main() {
+  echo -e '\n-----> Validating JSON'
+  for f in $(git ls-files '*.json'); do
+    echo -en "$f "
+    python -m json.tool <"${f}" >/dev/null
+    echo "✓"
+  done
+
+  echo -e '\n-----> Running shellcheck'
+  git grep -El '^#!/.+\b(bash|sh)\b' -- './*' ':(exclude)*.tmpl' | xargs shellcheck
+
+  echo -e '\n-----> Running terraform validate'
+  for d in $(git ls-files '*.tf' | xargs -n1 dirname | LC_ALL=C sort | uniq); do
+    echo -en "${d} "
+    terraform validate "${d}"
+    echo "✓"
+  done
+
+  echo -e '\n-----> Success!'
+}
+
+main "$@"


### PR DESCRIPTION
This validates JSON files, shell scripts and Terraform configs. 

Inspired by Travis's own Terraform repo tests script:
https://github.com/travis-infrastructure/terraform-config/blob/7ed91676a42e17e2e6d03ecaa699c3f615acd4bd/runtests#L43

Example run on my fork:
https://travis-ci.org/edmorley/devservices-aws/builds/255646833

In the future `terraform fmt` could be added to the checks run here.

Before merging, Travis will need enabling on this repo (I don't have permissions) via:
https://travis-ci.org/profile

Fixes #54 / https://bugzilla.mozilla.org/show_bug.cgi?id=1379211