### PR TITLE
Bug 1381391 - SNS topic for Servo VCS sync errors

### DIFF
--- a/vcssync/iam-roles.tf
+++ b/vcssync/iam-roles.tf
@@ -57,10 +57,37 @@ data "aws_iam_policy_document" "servo_ec2_instance_policy" {
             "${aws_cloudwatch_log_group.vcssync.arn}:log-stream:${aws_instance.servo_vcs_sync.id}",
         ]
     }
+
+    # Publish to Servo errors SNS topic.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "SNS:Publish",
+        ]
+        resources = [
+            "${aws_sns_topic.servo_errors.arn}",
+        ]
+    }
 }
 
 resource "aws_iam_role_policy" "vcs-sync-servo" {
     name = "vcs-sync-servo"
     role = "${aws_iam_role.servo-assume-role.id}"
     policy = "${data.aws_iam_policy_document.servo_ec2_instance_policy.json}"
+}
+
+data "aws_iam_policy_document" "sns_servo_errors_subscribe" {
+    statement = {
+        effect = "Allow"
+        actions = [
+            "SNS:Subscribe",
+        ]
+        resources = [
+            "${aws_sns_topic.servo_errors.arn}",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
 }

--- a/vcssync/sns.tf
+++ b/vcssync/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "servo_errors" {
+    name = "vcssync-servo-errors"
+    display_name = "Errors encountered during Servo VCS Sync operations"
+}
+
+resource "aws_sns_topic_policy" "servo_errors" {
+    arn = "${aws_sns_topic.servo_errors.arn}"
+    policy = "${data.aws_iam_policy_document.sns_servo_errors_subscribe.json}"
+}


### PR DESCRIPTION
We need an SNS topic for holding errors related to Servo VCS sync.
We plan to use the SNS topic to alert humans when errors occur.

This commit defines a new SNS topic. It is writable by the VCS Sync
EC2 instance. The world can subscribe to it (there should be no
private or sensitive data leaked in the error messages).