### PR TITLE
treeherder: Remove MySQL 5.6 specific parameter group

### DIFF
--- a/treeherder/iam.tf
+++ b/treeherder/iam.tf
@@ -64,7 +64,6 @@ data "aws_iam_policy_document" "treeherder_rds" {
         resources = [
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:treeherder-stage",
-            "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:pg:treeherder-mysql57",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-prod",
             "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:ri:treeherder-stage",

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -17,48 +17,6 @@ resource "aws_db_subnet_group" "treeherder-dbgrp" {
 }
 
 # coordinate name change with aws_iam_policy_document.treeherder_rds in iam.tf
-resource "aws_db_parameter_group" "treeherder-pg" {
-    name = "treeherder"
-    family = "mysql5.6"
-    description = "Main Treeherder parameter group"
-    parameter {
-        name = "character_set_server"
-        value = "utf8"
-    }
-    parameter {
-        name = "collation_server"
-        value = "utf8_bin"
-    }
-    parameter {
-        name = "log_output"
-        value = "FILE"
-    }
-    parameter {
-        name = "long_query_time"
-        value = "2"
-    }
-    parameter {
-        name = "slow_query_log"
-        value = "1"
-    }
-    parameter {
-        name = "sql_mode"
-        value = "NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
-    }
-    parameter {
-        name = "tx_isolation"
-        value = "READ-COMMITTED"
-    }
-    tags {
-        Name = "treeherder-prod-pg"
-        App = "treeherder"
-        Type = "pg"
-        Env = "prod"
-        Owner = "relops"
-    }
-}
-
-# coordinate name change with aws_iam_policy_document.treeherder_rds in iam.tf
 resource "aws_db_parameter_group" "treeherder-pg-mysql57" {
     name = "treeherder-mysql57"
     family = "mysql5.7"


### PR DESCRIPTION
Since all of the Treeherder RDS instances are now on MySQL 5.7.

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1378433