### PR TITLE
treeherder: Limit MySQL SELECT query execution time to 90s

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -37,6 +37,11 @@ resource "aws_db_parameter_group" "treeherder-pg-mysql57" {
         name = "long_query_time"
         value = "2"
     }
+    # Terminate SELECT queries that take longer than 90 seconds to complete.
+    parameter {
+        name = "max_execution_time"
+        value = "90000"
+    }
     parameter {
         name = "slow_query_log"
         value = "1"


### PR DESCRIPTION
To prevent runaway queries (eg from missing API parameter validation) from stacking up, causing performance issues / temp table overload.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1387258
https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_execution_time