### PR TITLE
treeherder: Bump stage/prod storage to 1TB

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -91,7 +91,7 @@ resource "aws_db_instance" "treeherder-dev-rds" {
 resource "aws_db_instance" "treeherder-stage-rds" {
     identifier = "treeherder-stage"
     storage_type = "gp2"
-    allocated_storage = 750
+    allocated_storage = 1000
     engine = "mysql"
     engine_version = "5.7.17"
     instance_class = "db.m4.xlarge"
@@ -122,7 +122,7 @@ resource "aws_db_instance" "treeherder-stage-rds" {
 resource "aws_db_instance" "treeherder-prod-rds" {
     identifier = "treeherder-prod"
     storage_type = "gp2"
-    allocated_storage = 750
+    allocated_storage = 1000
     engine = "mysql"
     engine_version = "5.7.17"
     instance_class = "db.m4.2xlarge"


### PR DESCRIPTION
The dev instance will need bumping to 1TB by hand, since it's not specified in the Terraform config. The prod-ro instance has already been bumped.

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1397712