### PR TITLE
treeherder: Bump dev instance storage from 750GB to 1TB

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -67,6 +67,7 @@ resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "rds:treeherder-prod-2017-01-24-07-06"
     storage_type = "gp2"
+    allocated_storage = 1000
     engine = "mysql"
     engine_version = "5.7.17"
     instance_class = "db.m4.xlarge"
@@ -154,6 +155,7 @@ resource "aws_db_instance" "treeherder-prod-ro-rds" {
     identifier = "treeherder-prod-ro"
     replicate_source_db = "${aws_db_instance.treeherder-prod-rds.id}"
     storage_type = "gp2"
+    allocated_storage = 1000
     engine = "mysql"
     engine_version = "5.7.17"
     instance_class = "db.m4.xlarge"


### PR DESCRIPTION
To bring it in line with stage/prod.

Whilst the dev instance's config makes use of `replicate_source_db` (which doesn't need/use the `allocated_storage` pref), from reading the Terraform AWS provider's source, it appears that for already created RDS instances, the `allocated_storage` value still will have an effect:
https://github.com/mozilla-platform-ops/devservices-aws/pull/66#issuecomment-328934106

Also explicitly defines `allocated_storage` for the read-only prod instance, which is already at 1TB.

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1397712