### PR TITLE
global: migrate to backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://moz-devservices.signin.aws.amazon.com/console
 
 Requirements
 ------------
-- Terraform v0.7.12+
+- Terraform v0.10.0+
 - AWS CLI
 - AWS credentials
 - (optional) [MFA helper scripts](https://github.com/mozilla-platform-ops/aws\_mfa\_scripts)

--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,8 @@ set -euf -o pipefail
 tfenv="$(basename "$(pwd)")"
 
 # Set up remote state
-terraform remote config -backend=s3 \
-    -backend-config="bucket=moz-devservices" \
+terraform init \
     -backend-config="key=tf_state/${tfenv}/terraform.tfstate" \
-    -backend-config="region=us-east-1"
 
 # Update modules
 terraform get

--- a/resources.tf
+++ b/resources.tf
@@ -2,6 +2,14 @@
 
 terraform {
     required_version = ">= 0.10.0"
+
+    backend "s3" {
+        encrypt = true
+        acl = "private"
+        bucket = "moz-devservices"
+        region = "us-east-1"
+        # The key should be passed via `terraform init` as part of init.sh.
+    }
 }
 
 # account_id = ${data.aws_caller_identity.current.account_id}
@@ -9,8 +17,8 @@ data "aws_caller_identity" "current" { }
 
 data "aws_availability_zones" "available" {}
 
-# Configure remote state
-# outputs can be accessed via ${data.terraform_remote_state.base.output_name}
+# Configure remote state for "base", which is heavily referenced.
+# Outputs can be accessed via ${data.terraform_remote_state.base.output_name}
 data "terraform_remote_state" "base" {
     backend = "s3"
     config {

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,7 +17,7 @@ main() {
   git grep -El '^#!/.+\b(bash|sh)\b' -- './*' ':(exclude)*.tmpl' | xargs shellcheck
 
   echo -e '\n-----> Running terraform validate'
-  for d in $(git ls-files '*.tf' | xargs -n1 dirname | LC_ALL=C sort | uniq); do
+  for d in $(git ls-files '*.tf' | xargs -n1 dirname | LC_ALL=C sort | grep -E -v '^\.$' | uniq); do
     echo -en "${d} "
     terraform validate "${d}"
     echo "✓"


### PR DESCRIPTION
Terraform 0.9 introduced backends. Backends are apparently the
new way to do remote state.

This commit upgrades everything to use backends.

Essentially, this meant adding a backend {} in resources.tf and
updating init.sh to use `terraform init` instead of `terraform remote`.
Since most backend configs are constant, init.sh is simplified to
only specify the per-environment S3 key to use.

On my machine, `runtests.sh` was failing on 0.10. This appears to
be a change in behavior in either 0.9 or 0.10 with regards to
validating directories that don't have a backend configured.

The root directory has no explicit state/resources. So we exclude
it from testing.