### PR TITLE
hgmo: update CloudFront certificate

### DIFF
--- a/hgmo/cloudfront.tf
+++ b/hgmo/cloudfront.tf
@@ -40,7 +40,7 @@ resource "aws_cloudfront_distribution" "bundles" {
     }
 
     viewer_certificate {
-        iam_certificate_id = "ASCAIRLY6OFDMQHNPMX5I"
+        acm_certificate_arn = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/2d14b270-e4ec-4a12-8269-161b65ad5ccf"
         ssl_support_method = "sni-only"
         minimum_protocol_version = "TLSv1"
     }


### PR DESCRIPTION
We uploaded a new certificate for the CloudFront distribution a few
weeks back. It looks like this was done manually because terraform
is still referencing the old certificate ID.

This commit points terraform at the ARN of the new ACM-hosted
certificate. After this change, `terraform plan` for hgmo says no
changes are necessary, as expected.