### PR TITLE
WPT Sync fixups

### DIFF
--- a/base/iam-policies.tf
+++ b/base/iam-policies.tf
@@ -35,6 +35,7 @@ data "aws_iam_policy_document" "s3-ssh-keys-access" {
             identifiers = [
                 "${aws_iam_role.ec2-assume-role.arn}",
                 "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/vcs-sync-servo-assume-role",
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/wpt-sync-testing-assume-role",
             ]
         }
         resources = ["${aws_s3_bucket.key_bucket.arn}"]
@@ -51,6 +52,7 @@ data "aws_iam_policy_document" "s3-ssh-keys-access" {
             identifiers = [
                 "${aws_iam_role.ec2-assume-role.arn}",
                 "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/vcs-sync-servo-assume-role",
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/wpt-sync-testing-assume-role",
             ]
         }
         resources = ["${aws_s3_bucket.key_bucket.arn}/*"]

--- a/vcssync/ec2-wpthost.tf
+++ b/vcssync/ec2-wpthost.tf
@@ -22,6 +22,7 @@ resource "aws_instance" "wpt_vcs_sync_testing" {
     instance_type = "t2.medium"
     instance_initiated_shutdown_behavior = "terminate"
 
+    iam_instance_profile = "${aws_iam_instance_profile.wpt-sync-testing.name}"
     user_data = "${file("files/jumphost-userdata.sh")}"
 
     key_name = "${var.key_name}"

--- a/vcssync/iam-roles.tf
+++ b/vcssync/iam-roles.tf
@@ -91,3 +91,32 @@ data "aws_iam_policy_document" "sns_servo_errors_subscribe" {
         }
     }
 }
+
+resource "aws_iam_instance_profile" "wpt-sync-testing" {
+    name = "wpt-sync-testing"
+    role = "${aws_iam_role.wpt-sync-testing-assume-role.name}"
+}
+
+data "aws_iam_policy_document" "wpt_sync_instance_policy" {
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:Get*",
+            "s3:List*",
+        ]
+        resources = [
+            "arn:aws:s3:::${data.terraform_remote_state.base.key_bucket_id}/*",
+        ]
+    }
+}
+
+resource "aws_iam_role" "wpt-sync-testing-assume-role" {
+    name = "wpt-sync-testing-assume-role"
+    assume_role_policy = "${data.aws_iam_policy_document.ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy" "wpt-sync-testing" {
+    name = "wpt-sync-testing"
+    role = "${aws_iam_role.wpt-sync-testing-assume-role.id}"
+    policy = "${data.aws_iam_policy_document.wpt_sync_instance_policy.json}"
+}

--- a/vcssync/iam-roles.tf
+++ b/vcssync/iam-roles.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "ec2_assume_role" {
 
 resource "aws_iam_instance_profile" "servo" {
     name = "vcs-sync-servo"
-    roles = ["${aws_iam_role.servo-assume-role.name}"]
+    role = "${aws_iam_role.servo-assume-role.name}"
 }
 
 resource "aws_iam_role" "servo-assume-role" {


### PR DESCRIPTION
These changes are needed so the WPT Sync test host has access to the SSH keys and can actively synchronize them.