### PR TITLE
githubwebhooks: allow infosec-prod account to access unfiltered GitHub stream

### DIFF
--- a/githubwebhooks/iam-roles.tf
+++ b/githubwebhooks/iam-roles.tf
@@ -146,3 +146,22 @@ resource "aws_iam_role_policy" "lambda_github_webhooks_pulse" {
     role = "${aws_iam_role.lambda_github_webhooks_pulse.id}"
     policy = "${data.aws_iam_policy_document.lambda_github_webhooks_pulse.json}"
 }
+
+data "aws_iam_policy_document" "sns_webhooks_all" {
+    # Grant access to infosec-prod account.
+    statement = {
+        sid = "github_webhooks_all_infosec_subscribe"
+        effect = "Allow"
+        actions = [
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:Subscribe",
+        ]
+        resources = [
+            "${aws_sns_topic.webhooks_all.arn}",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["371522382791"]
+        }
+    }
+}

--- a/githubwebhooks/sns.tf
+++ b/githubwebhooks/sns.tf
@@ -2,6 +2,11 @@ resource "aws_sns_topic" "webhooks_all" {
     name = "github-webhooks-all"
 }
 
+resource "aws_sns_topic_policy" "webhooks_all" {
+    arn = "${aws_sns_topic.webhooks_all.arn}"
+    policy = "${data.aws_iam_policy_document.sns_webhooks_all.json}"
+}
+
 resource "aws_sns_topic" "webhooks_public" {
     name = "github-webhooks-public"
 }


### PR DESCRIPTION
This was requested by @gene1wood.

There is a default policy on SNS topics. The first portion of the
added policy copies what was present on the topic.