### PR TITLE
Bug 1425593 - Create S3 bucket for Mercurial bundles in use2

### DIFF
--- a/hgmo/iam-roles.tf
+++ b/hgmo/iam-roles.tf
@@ -21,6 +21,7 @@ data "aws_iam_policy_document" "hg_bundles_use1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
+            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -38,9 +39,47 @@ data "aws_iam_policy_document" "hg_bundles_use1" {
         actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
+            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_use1.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+}
+
+data "aws_iam_policy_document" "hg_bundles_use2" {
+    # Grant bundler user access to upload and modify objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_use2.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["${aws_iam_user.hgbundler.arn}"]
+        }
+    }
+
+    # Grant all access to read S3 objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObjectTorrent",
+            "s3:GetObject",
+            "s3:ListBucket",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_bundles_use2.arn}/*",
         ]
         principals {
             type = "AWS"
@@ -56,6 +95,7 @@ data "aws_iam_policy_document" "hg_bundles_usw1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
+            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -73,6 +113,7 @@ data "aws_iam_policy_document" "hg_bundles_usw1" {
         actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
+            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_usw1.arn}/*",
@@ -91,6 +132,7 @@ data "aws_iam_policy_document" "hg_bundles_usw2" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
+            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -108,6 +150,7 @@ data "aws_iam_policy_document" "hg_bundles_usw2" {
         actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
+            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_usw2.arn}/*",
@@ -126,6 +169,7 @@ data "aws_iam_policy_document" "hg_bundles_euc1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
+            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -143,6 +187,7 @@ data "aws_iam_policy_document" "hg_bundles_euc1" {
         actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
+            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_euc1.arn}/*",

--- a/hgmo/provider.tf
+++ b/hgmo/provider.tf
@@ -9,6 +9,11 @@ provider "aws" {
 }
 
 provider "aws" {
+    alias = "use2"
+    region = "us-east-2"
+}
+
+provider "aws" {
     alias = "usw1"
     region = "us-west-1"
 }

--- a/hgmo/s3.tf
+++ b/hgmo/s3.tf
@@ -45,6 +45,50 @@ resource "aws_s3_bucket_policy" "hg_bundles_use1" {
     policy = "${data.aws_iam_policy_document.hg_bundles_use1.json}"
 }
 
+resource "aws_s3_bucket" "hg_bundles_use2" {
+    # Buckets are pinned to a specific region and therefore have to use
+    # an explicit provider for that region.
+    provider = "aws.use2"
+    bucket = "moz-hg-bundles-us-east-2"
+    acl = ""
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1041173"
+    }
+
+    # Serve the auto-generated index when / is requested.
+    website {
+        index_document = "index.html"
+    }
+
+    # Send access logs to S3 so we can audit and monitor.
+    logging {
+        target_bucket = "moz-devservices-logging-us-east-2"
+        target_prefix = "s3/hg-bundles/"
+    }
+
+    # Objects automatically expire after 1 week.
+    lifecycle_rule {
+        enabled = true
+        prefix = ""
+        expiration {
+            days = 7
+        }
+        noncurrent_version_expiration {
+            days = 1
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_bundles_use2" {
+    provider = "aws.use2"
+    bucket = "${aws_s3_bucket.hg_bundles_use2.bucket}"
+    policy = "${data.aws_iam_policy_document.hg_bundles_use2.json}"
+}
+
 resource "aws_s3_bucket" "hg_bundles_usw1" {
     provider = "aws.usw1"
     bucket = "moz-hg-bundles-us-west-1"


### PR DESCRIPTION
We apparently have TaskCluster CI running in us-east-2. We should
be hosting Mercurial bundles from there so all tasks in that region
don't incur cross-region traffic.

There is a lot of copy pasta in these files. I tried to refactor
things to use "count" and variable expansion so we only need to
define each resource once. However, terraform doesn't seem to
allow the "provider" variable to be dynamic. I suspect we could
use templates or modules. But this is beyond my terraform knowledge.
So we incur the copy pasta.