### PR TITLE
Add s3 bucket to store Mercurial backups

### DIFF
--- a/hgmo/iam-roles.tf
+++ b/hgmo/iam-roles.tf
@@ -21,7 +21,6 @@ data "aws_iam_policy_document" "hg_bundles_use1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
-            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -34,12 +33,25 @@ data "aws_iam_policy_document" "hg_bundles_use1" {
     }
 
     # Grant all access to read S3 objects.
+
+    // s3:ListBucket is a prerequisite for s3:GetObject.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:ListBucket",
+        ]
+        resources = ["${aws_s3_bucket.hg_bundles_use1.arn}"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+
     statement = {
         effect = "Allow"
         actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
-            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_use1.arn}/*",
@@ -58,7 +70,6 @@ data "aws_iam_policy_document" "hg_bundles_use2" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
-            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -74,9 +85,20 @@ data "aws_iam_policy_document" "hg_bundles_use2" {
     statement = {
         effect = "Allow"
         actions = [
+            "s3:ListBucket",
+        ]
+        resources = ["${aws_s3_bucket.hg_bundles_use2.arn}"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+
+    statement = {
+        effect = "Allow"
+        actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
-            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_use2.arn}/*",
@@ -95,7 +117,6 @@ data "aws_iam_policy_document" "hg_bundles_usw1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
-            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -111,9 +132,20 @@ data "aws_iam_policy_document" "hg_bundles_usw1" {
     statement = {
         effect = "Allow"
         actions = [
+            "s3:ListBucket",
+        ]
+        resources = ["${aws_s3_bucket.hg_bundles_usw1.arn}"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+
+    statement = {
+        effect = "Allow"
+        actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
-            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_usw1.arn}/*",
@@ -132,7 +164,6 @@ data "aws_iam_policy_document" "hg_bundles_usw2" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
-            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -148,9 +179,20 @@ data "aws_iam_policy_document" "hg_bundles_usw2" {
     statement = {
         effect = "Allow"
         actions = [
+            "s3:ListBucket",
+        ]
+        resources = ["${aws_s3_bucket.hg_bundles_usw2.arn}"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+
+    statement = {
+        effect = "Allow"
+        actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
-            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_usw2.arn}/*",
@@ -169,7 +211,6 @@ data "aws_iam_policy_document" "hg_bundles_euc1" {
         actions = [
             "s3:DeleteObject",
             "s3:GetObject",
-            "s3:ListBucket",
             "s3:PutObject",
         ]
         resources = [
@@ -185,9 +226,20 @@ data "aws_iam_policy_document" "hg_bundles_euc1" {
     statement = {
         effect = "Allow"
         actions = [
+            "s3:ListBucket",
+        ]
+        resources = ["${aws_s3_bucket.hg_bundles_euc1.arn}"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+
+    statement = {
+        effect = "Allow"
+        actions = [
             "s3:GetObjectTorrent",
             "s3:GetObject",
-            "s3:ListBucket",
         ]
         resources = [
             "${aws_s3_bucket.hg_bundles_euc1.arn}/*",

--- a/hgmo/iam-roles.tf
+++ b/hgmo/iam-roles.tf
@@ -321,3 +321,25 @@ data "aws_iam_policy_document" "s3_hg_events_usw2" {
         }
     }
 }
+
+data "aws_iam_policy_document" "s3_hg_backups" {
+    # Grant bundler user access to upload objects.
+    statement = {
+        effect = "Allow"
+        actions = [
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject",
+        ]
+        resources = [
+            "${aws_s3_bucket.hg_backups.arn}",
+            "${aws_s3_bucket.hg_backups.arn}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = [
+                "${aws_iam_user.hgbundler.arn}",
+            ]
+        }
+    }
+}

--- a/hgmo/s3.tf
+++ b/hgmo/s3.tf
@@ -238,3 +238,29 @@ resource "aws_s3_bucket_policy" "hg_events_usw2" {
     bucket = "${aws_s3_bucket.hg_events_usw2.bucket}"
     policy = "${data.aws_iam_policy_document.s3_hg_events_usw2.json}"
 }
+
+# Bucket to hold backups of Mercurial repositories.
+
+resource "aws_s3_bucket" "hg_backups" {
+    provider = "aws.usw2"
+    bucket = "moz-hg-backups"
+    acl = "private"
+
+    tags {
+        App = "hgmo"
+        Env = "prod"
+        Owner = "gps@mozilla.com"
+        Bugid = "1435904"
+    }
+
+    logging = {
+        target_bucket = "moz-devservices-logging-us-west-2"
+        target_prefix = "s3/hg-backups"
+    }
+}
+
+resource "aws_s3_bucket_policy" "hg_backups" {
+    provider = "aws.usw2"
+    bucket = "${aws_s3_bucket.hg_backups.bucket}"
+    policy = "${data.aws_iam_policy_document.s3_hg_backups.json}"
+}

--- a/hgmo/s3.tf
+++ b/hgmo/s3.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "hg_bundles_use1" {
     # an explicit provider for that region.
     provider = "aws.use1"
     bucket = "moz-hg-bundles-us-east-1"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"
@@ -50,7 +50,7 @@ resource "aws_s3_bucket" "hg_bundles_use2" {
     # an explicit provider for that region.
     provider = "aws.use2"
     bucket = "moz-hg-bundles-us-east-2"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"
@@ -92,7 +92,7 @@ resource "aws_s3_bucket_policy" "hg_bundles_use2" {
 resource "aws_s3_bucket" "hg_bundles_usw1" {
     provider = "aws.usw1"
     bucket = "moz-hg-bundles-us-west-1"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"
@@ -131,7 +131,7 @@ resource "aws_s3_bucket_policy" "hg_bundles_usw1" {
 resource "aws_s3_bucket" "hg_bundles_usw2" {
     provider = "aws.usw2"
     bucket = "moz-hg-bundles-us-west-2"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"
@@ -177,7 +177,7 @@ resource "aws_s3_bucket_policy" "hg_bundles_usw2" {
 resource "aws_s3_bucket" "hg_bundles_euc1" {
     provider = "aws.euc1"
     bucket = "moz-hg-bundles-eu-central-1"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"
@@ -218,7 +218,7 @@ resource "aws_s3_bucket_policy" "hg_bundles_euc1" {
 resource "aws_s3_bucket" "hg_events_usw2" {
     provider = "aws.usw2"
     bucket = "moz-hg-events-us-west-2"
-    acl = ""
+    acl = "private"
 
     tags {
         App = "hgmo"


### PR DESCRIPTION
We have several gigabytes of old repos sitting on an NFS volume
in SCL3. It's cheaper to store them in S3. Plus, we'll soon be
migrating a bunch of data and it is easier if we have less data to
migrate.