### PR TITLE
treeherder: Raise MySQL max_execution_time from 90s to 180s

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -37,10 +37,10 @@ resource "aws_db_parameter_group" "treeherder-pg-mysql57" {
         name = "long_query_time"
         value = "2"
     }
-    # Terminate SELECT queries that take longer than 90 seconds to complete.
+    # Terminate SELECT queries that take longer than 180 seconds to complete.
     parameter {
         name = "max_execution_time"
-        value = "90000"
+        value = "180000"
     }
     parameter {
         name = "slow_query_log"


### PR DESCRIPTION
So that:
* it's slightly less annoying for people performing ad-hoc queries
  on the read-only replica (eg via Redash).
* background analysis tasks (eg for SETA) are less likely to time
  out until we have time to optimise their queries.

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1409402