### PR TITLE
treeherder: Upgrade treeherder-dev MySQL from 5.7.19 to 5.7.21

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -78,7 +78,7 @@ resource "aws_db_instance" "treeherder-dev-rds" {
     storage_type = "gp2"
     allocated_storage = 1000
     engine = "mysql"
-    engine_version = "5.7.19"
+    engine_version = "5.7.21"
     instance_class = "db.m4.xlarge"
     maintenance_window = "Sun:08:00-Sun:08:30"
     multi_az = false


### PR DESCRIPTION
Release notes:
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-20.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-21.html

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1413542