### PR TITLE
Add gps2 user

### DIFF
--- a/base/iam-users_groups.tf
+++ b/base/iam-users_groups.tf
@@ -13,7 +13,8 @@ resource "aws_iam_group_membership" "admin-groupmem" {
         "${aws_iam_user.dividehex.name}",
         "${aws_iam_user.dhouse.name}",
         "${aws_iam_user.fubar.name}",
-        "${aws_iam_user.gps.name}"
+        "${aws_iam_user.gps.name}",
+        "${aws_iam_user.gps2.name}",
     ]
 }
 resource "aws_iam_user" "dividehex" {
@@ -27,6 +28,11 @@ resource "aws_iam_user" "fubar" {
 }
 resource "aws_iam_user" "gps" {
     name = "gps"
+}
+# IAM limits you to 2 access keys per user and gps uses separate access keys
+# per physical device. So he has multiple users.
+resource "aws_iam_user" "gps2" {
+    name = "gps2"
 }
 resource "aws_iam_user" "hwine" {
     name = "hwine"


### PR DESCRIPTION
IAM users can only have up to 2 access keys. I like to use separate
keys per physical device so I can more easily audit for key usage
and so if/when a key is revoked, I'm not locked out of access on all
my devices.

So let's create a gps2 user so it can hold an additional 2 access keys.