### PR TITLE
Move iam:DeleteVirtualMFADevice to non-conditional statement

### DIFF
--- a/base/files/manage_own_credentials.json
+++ b/base/files/manage_own_credentials.json
@@ -2,12 +2,13 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "AllowUsersToCreateEnableResyncTheirOwnVirtualMFADevice",
+            "Sid": "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice",
             "Effect": "Allow",
             "Action": [
                 "iam:CreateVirtualMFADevice",
                 "iam:EnableMFADevice",
-                "iam:ResyncMFADevice"
+                "iam:ResyncMFADevice",
+                "iam:DeleteVirtualMFADevice"
             ],
             "Resource": [
                 "arn:aws:iam::699292812394:mfa/${aws:username}",
@@ -15,11 +16,10 @@
             ]
         },
         {
-            "Sid": "AllowUsersToDeactivateDeleteTheirOwnVirtualMFADevice",
+            "Sid": "AllowUsersToDeactivateTheirOwnVirtualMFADevice",
             "Effect": "Allow",
             "Action": [
-                "iam:DeactivateMFADevice",
-                "iam:DeleteVirtualMFADevice"
+                "iam:DeactivateMFADevice"
             ],
             "Resource": [
                 "arn:aws:iam::699292812394:mfa/${aws:username}",


### PR DESCRIPTION
This fixes an issue that prevented users from adding a virtual mfa device.  This policy now matches up with the aws example.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_delegate-permissions_examples.html#creds-policies-mfa-console