### PR TITLE
treeherder: Upgrade treeherder-{stage,prod-ro} MySQL to 5.7.23

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -109,7 +109,7 @@ resource "aws_db_instance" "treeherder-stage-rds" {
     storage_type = "gp2"
     allocated_storage = 1000
     engine = "mysql"
-    engine_version = "5.7.17"
+    engine_version = "5.7.23"
     instance_class = "db.m4.xlarge"
     backup_retention_period = 1
     backup_window = "07:00-07:30"
@@ -175,7 +175,7 @@ resource "aws_db_instance" "treeherder-prod-ro-rds" {
     storage_type = "gp2"
     allocated_storage = 1000
     engine = "mysql"
-    engine_version = "5.7.17"
+    engine_version = "5.7.23"
     instance_class = "db.m4.xlarge"
     maintenance_window = "Sun:08:00-Sun:08:30"
     multi_az = false


### PR DESCRIPTION
treeherder-dev was updated in #89 - this does the same for treeherder-stage and treeherder-prod-ro (the latter since AWS requires that replicas be updated before the master, so we might as well get it out of the way now given that the RO instance is non-critical).

Release notes:
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-18.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-19.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-20.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-21.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-22.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-23.html

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1413542