### PR TITLE
treeherder: Upgrade treeherder-prod MySQL to 5.7.23

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -143,7 +143,7 @@ resource "aws_db_instance" "treeherder-prod-rds" {
     storage_type = "gp2"
     allocated_storage = 1000
     engine = "mysql"
-    engine_version = "5.7.17"
+    engine_version = "5.7.23"
     instance_class = "db.m4.2xlarge"
     username = "th_admin"
     password = "XXXXXXXXXXXXXXXX"


### PR DESCRIPTION
treeherder-{dev,stage,prod-ro} were updated in #89 and #95 - this does the same for treeherder-prod.

Release notes:
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-18.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-19.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-20.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-21.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-22.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-23.html

Refs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1413542