### PR TITLE
[treeherder] upgrade treeherder-dev to iops storage

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -75,8 +75,9 @@ data "aws_db_snapshot" "treeherder-prod-latest" {
 resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "${data.aws_db_snapshot.treeherder-prod-latest.id}"
-    storage_type = "gp2"
-    allocated_storage = 1000
+    storage_type = "io1"
+    iops = 6000
+    allocated_storage = 1100
     engine = "mysql"
     engine_version = "5.7.23"
     instance_class = "db.m5.xlarge"


### PR DESCRIPTION
This will convert treeherder-dev from ssd to provisioned iops with iops set to 6000.  It also aligns the change in storage capacity from 1000GB to 1100GB which was done previous from the aws UI.