### PR TITLE
Bug 1567257 - Increase IOPS for treeherder-prod

### DIFF
--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -75,8 +75,7 @@ data "aws_db_snapshot" "treeherder-prod-latest" {
 resource "aws_db_instance" "treeherder-dev-rds" {
     identifier = "treeherder-dev"
     snapshot_identifier = "${data.aws_db_snapshot.treeherder-prod-latest.id}"
-    storage_type = "io1"
-    iops = 6000
+    storage_type = "gp2"
     allocated_storage = 1100
     engine = "mysql"
     engine_version = "5.7.23"

--- a/treeherder/rds.tf
+++ b/treeherder/rds.tf
@@ -141,7 +141,7 @@ resource "aws_db_instance" "treeherder-stage-rds" {
 resource "aws_db_instance" "treeherder-prod-rds" {
     identifier = "treeherder-prod"
     storage_type = "gp2"
-    allocated_storage = 1000
+    allocated_storage = 2000
     engine = "mysql"
     engine_version = "5.7.23"
     instance_class = "db.m5.2xlarge"


### PR DESCRIPTION
Doubling the storage size from 1Tb to 2Tb will increase our IOPS cap from 3,000 IOPS
to 6,000 IOPS. This will allow us to not hit the IOPS cap when we have Read IOPS spikes
as seen on [bug 1553199](https://bugzilla.mozilla.org/show_bug.cgi?id=1553199).

We will also revert the change in [bug 1565042](https://bugzilla.mozilla.org/show_bug.cgi?id=1565042)